### PR TITLE
Move store creation and loading logic into Database instance

### DIFF
--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -158,7 +158,7 @@ void printStoreStats(ConfigDB::Database& db, bool detailed)
 {
 	for(unsigned i = 0; auto store = db.getStore(i); ++i) {
 		Serial << F("Store '") << store->getName() << "':" << endl;
-		Serial << F("  Root: ") << store->typeinfo().objinfo[0]->structSize << endl;
+		Serial << F("  Root: ") << store->typeinfo().structSize << endl;
 		printStringPool(store->stringPool, detailed);
 		printArrayPool(store->arrayPool, detailed);
 

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -70,7 +70,7 @@ void checkPerformance(BasicConfig& db)
 		unsigned store = 0;
 		for(int i = 0; i < rounds; i++) {
 			times.start();
-			auto store = db.getStore(i % db.getTypeinfo().storeCount);
+			auto store = db.getStore(i % db.typeinfo.storeCount);
 			times.update();
 		}
 		Serial << times << endl;

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -66,7 +66,20 @@ void checkPerformance(BasicConfig& db)
 
 	Serial << _F("Evaluating load times ...") << endl;
 	{
-		Profiling::MicroTimes times(F("Load store"));
+		// Load same cache multiple times
+		Profiling::MicroTimes times(F("Verify load caching"));
+		unsigned store = 0;
+		for(int i = 0; i < rounds; i++) {
+			times.start();
+			auto store = db.getStore(1);
+			times.update();
+		}
+		Serial << times << endl;
+	}
+
+	{
+		// Load different stores in sequence to bypass caching
+		Profiling::MicroTimes times(F("Load all stores"));
 		unsigned store = 0;
 		for(int i = 0; i < rounds; i++) {
 			times.start();

--- a/samples/Basic_Config/basic-config.cfgdb
+++ b/samples/Basic_Config/basic-config.cfgdb
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "store": "json",
+  "store": true,
   "properties": {
     "general": {
       "type": "object",
-      "store": "json",
+      "store": true,
       "properties": {
         "device_name": {
           "type": "string",
@@ -104,7 +104,7 @@
     },
     "color": {
       "type": "object",
-      "store": "json",
+      "store": true,
       "properties": {
         "startup_color": {
           "type": "string",
@@ -280,7 +280,7 @@
     },
     "events": {
       "type": "object",
-      "store": "json",
+      "store": true,
       "properties": {
         "color_interval_ms": {
           "type": "integer",

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -84,7 +84,7 @@ String ObjectInfo::getTypeDesc() const
 	return s;
 }
 
-Object::Object(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, store, store.getObjectDataPtr(typeinfo))
+Object::Object(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, &store, store.getObjectDataPtr(typeinfo))
 {
 }
 
@@ -119,12 +119,12 @@ Object Object::getObject(unsigned index)
 
 	auto typ = typeinfo().objinfo[index];
 	auto offset = typ->getOffset();
-	return Object(*typ, *this, static_cast<uint8_t*>(data) + offset);
+	return Object(*typ, this, static_cast<uint8_t*>(data) + offset);
 }
 
 Object Object::findObject(const char* name, size_t length)
 {
-	if(typeinfo().type != ObjectType::Object) {
+	if(typeinfo().type > ObjectType::Object) {
 		return {};
 	}
 	for(unsigned i = 0; i < typeinfo().objectCount; ++i) {
@@ -137,7 +137,7 @@ Object Object::findObject(const char* name, size_t length)
 
 Property Object::findProperty(const char* name, size_t length)
 {
-	if(typeinfo().type != ObjectType::Object) {
+	if(typeinfo().type > ObjectType::Object) {
 		return {};
 	}
 	for(unsigned i = 0; i < typeinfo().propertyCount; ++i) {
@@ -151,7 +151,7 @@ Property Object::findProperty(const char* name, size_t length)
 
 bool Object::commit()
 {
-	return getStore().commit();
+	return getStore().save();
 }
 
 Database& Object::getDatabase()

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -17,9 +17,7 @@
  *
  ****/
 
-#include "include/ConfigDB/Object.h"
-#include "include/ConfigDB/ObjectArray.h"
-#include "include/ConfigDB/Store.h"
+#include "include/ConfigDB/Database.h"
 
 namespace ConfigDB
 {
@@ -86,6 +84,11 @@ String ObjectInfo::getTypeDesc() const
 
 Object::Object(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, &store, store.getObjectDataPtr(typeinfo))
 {
+}
+
+std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinfo)
+{
+	return db.openStore(typeinfo);
 }
 
 Store& Object::getStore()

--- a/src/ObjectArray.cpp
+++ b/src/ObjectArray.cpp
@@ -39,7 +39,7 @@ Object ObjectArray::getObject(unsigned index)
 	}
 	auto& itemType = *typeinfo().objinfo[0];
 	auto itemData = (index < array.getCount()) ? array[index] : array.add(itemType);
-	return Object(itemType, *this, itemData);
+	return Object(itemType, this, itemData);
 }
 
 } // namespace ConfigDB

--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -27,6 +27,7 @@ bool PoolData::ensureCapacity(size_t required)
 		return true;
 	}
 	size_t increment = std::max(4, capacity / 4);
+	increment = std::max(increment, 8U / itemSize);
 	size_t newCapacity = std::max(required, capacity + increment);
 	auto newBuffer = realloc(buffer, getItemSize(newCapacity));
 	if(!newBuffer) {

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -73,7 +73,7 @@ public:
 	{
 	}
 
-	ArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, parent, id)
+	ArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, &parent, id)
 	{
 	}
 
@@ -110,7 +110,7 @@ public:
 	{
 	}
 
-	StringArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, parent, id)
+	StringArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, &parent, id)
 	{
 	}
 

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -26,6 +26,7 @@
 namespace ConfigDB
 {
 struct DatabaseInfo {
+	const FlashString& name;
 	uint32_t storeCount;
 	const ObjectInfo* stores[];
 };

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -93,10 +93,15 @@ public:
 	const DatabaseInfo& typeinfo;
 
 private:
+	friend class Store;
+
 	CString path;
 	Format format{};
-	const ObjectInfo* storeType{}; ///< Which store we hold a weak reference to
-	std::weak_ptr<Store> storeRef;
+
+	// Hold store open for a brief period to avoid thrashing
+	static const ObjectInfo* storeType;
+	static std::shared_ptr<Store> storeRef;
+	static bool callbackQueued;
 };
 
 /**

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -25,10 +25,10 @@
 #include <debug_progmem.h>
 
 #define CONFIGDB_OBJECT_TYPE_MAP(XX)                                                                                   \
+	XX(Store)                                                                                                          \
 	XX(Object)                                                                                                         \
 	XX(Array)                                                                                                          \
-	XX(ObjectArray)                                                                                                    \
-	XX(Store)
+	XX(ObjectArray)
 
 namespace ConfigDB
 {
@@ -96,7 +96,7 @@ public:
 
 	Object(const ObjectInfo& typeinfo, Store& store);
 
-	Object(const ObjectInfo& typeinfo, Object& parent, void* data) : typeinfoPtr(&typeinfo), parent(&parent), data(data)
+	Object(const ObjectInfo& typeinfo, Object* parent, void* data) : typeinfoPtr(&typeinfo), parent(parent), data(data)
 	{
 	}
 
@@ -202,7 +202,7 @@ public:
 	{
 	}
 
-	ObjectTemplate(Object& parent, void* data) : Object(ClassType::typeinfo, parent, data)
+	ObjectTemplate(Object& parent, void* data) : Object(ClassType::typeinfo, &parent, data)
 	{
 	}
 };

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -111,7 +111,7 @@ public:
 private:
 	Item makeItem(void* itemData)
 	{
-		return Item(*this, *static_cast<typename Item::Struct*>(itemData));
+		return Item(*this, *typename Item::Struct::Ptr(itemData));
 	}
 };
 

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -42,7 +42,7 @@ public:
 	Object addItem()
 	{
 		auto& itemType = getItemType();
-		return Object(itemType, *this, getArray().add(itemType));
+		return Object(itemType, this, getArray().add(itemType));
 	}
 
 	bool removeItem(unsigned index)
@@ -84,7 +84,7 @@ public:
 	{
 	}
 
-	ObjectArrayTemplate(Object& parent, void* data) : ObjectArray(ClassType::typeinfo, parent, data)
+	ObjectArrayTemplate(Object& parent, void* data) : ObjectArray(ClassType::typeinfo, &parent, data)
 	{
 	}
 

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -59,10 +59,9 @@ String toString(PropertyType type);
  * @brief Property metadata
  */
 struct PropertyInfo {
-	// Don't access these directly!
+	PropertyType type;
 	const FlashString& name;
 	const FlashString* defaultValue; ///< Only required for strings
-	PropertyType type;
 
 	static const PropertyInfo empty;
 

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -432,24 +432,25 @@ def generate_database(db: Database) -> CodeLines:
                 '}',
             ],
         ],
-        [])
+        [
+            '',
+            f'const DatabaseInfo {db.typename}::typeinfo PROGMEM {{',
+            [
+                f'{strings[db.name]},',
+                f'{len(db.children)},',
+                '{',
+                [f'&{store.typename}::typeinfo,' for store in db.children],
+                '}'
+            ],
+            '};'
+        ])
 
     for store in db.children:
         lines.append(generate_object(store))
 
     lines.header += ['};']
 
-    lines.source += [
-        '',
-        f'const DatabaseInfo {db.typename}::typeinfo PROGMEM {{',
-        [
-            f'{len(db.children)},',
-            '{',
-            [f'&{store.typename}::typeinfo,' for store in db.children],
-            '}'
-        ], '};'
-    ]
-
+    # Insert this at end once string table has been populated
     lines.source[:0] = [
         f'#include "{db.name}.h"',
         '',


### PR DESCRIPTION
This PR removes `Store` class definitions from the generated code and moves all the Store opening and loading logic into the Database.

Rather than just maintaining a weak_ptr for each store type, the `Database` keeps a single strong `shared_ptr` for the most recently opened store. This gets disposed using the task queue so doesn't hang around long, but accommodates the most likely scenario where multiple database accessess occur in succession.

The **json** schema annotation is now just used as a marker and can be set to anything (typically just **true**). Applications can create their own Database implementation and customise by overriding the `createStore` method.

This also allows some simplification to the generator script.
