### PR TITLE
Don't store pointers in objects

### DIFF
--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -78,6 +78,12 @@ IMPORT_FSTR(sampleConfig, PROJECT_DIR "/sample-config.json")
 		for(unsigned i = 0; i < 16; ++i) {
 			item.values.addItem(os_random());
 		}
+
+		Serial << "old note = " <<  item.notes[0] << endl;
+		item.notes[0] = F("Overwriting nice pin");
+		Serial << "new note = " <<  item.notes[0] << endl;
+		assert(String(item.notes[0]) == F("Overwriting nice pin"));
+
 		item.commit();
 		Serial << channels.getPath() << " = " << item << endl;
 	}

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -84,6 +84,10 @@ IMPORT_FSTR(sampleConfig, PROJECT_DIR "/sample-config.json")
 		Serial << "new note = " <<  item.notes[0] << endl;
 		assert(String(item.notes[0]) == F("Overwriting nice pin"));
 
+		item.notes.insertItem(0, F("Inserted at #0"));
+		item.notes.insertItem(2, F("Inserted at #2"));
+
+
 		item.commit();
 		Serial << channels.getPath() << " = " << item << endl;
 	}
@@ -91,6 +95,7 @@ IMPORT_FSTR(sampleConfig, PROJECT_DIR "/sample-config.json")
 	{
 		BasicConfig::General::SupportedColorModels models(db);
 		models.addItem(F("New Model #") + os_random());
+		models.insertItem(0, F("Inserted at #0"));
 		models.commit();
 		Serial << models.getPath() << " = " << models << endl;
 	}

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -68,10 +68,9 @@ void checkPerformance(BasicConfig& db)
 	{
 		// Load same cache multiple times
 		Profiling::MicroTimes times(F("Verify load caching"));
-		unsigned store = 0;
 		for(int i = 0; i < rounds; i++) {
 			times.start();
-			auto store = db.getStore(1);
+			db.getStore(1);
 			times.update();
 		}
 		Serial << times << endl;
@@ -80,7 +79,6 @@ void checkPerformance(BasicConfig& db)
 	{
 		// Load different stores in sequence to bypass caching
 		Profiling::MicroTimes times(F("Load all stores"));
-		unsigned store = 0;
 		for(int i = 0; i < rounds; i++) {
 			times.start();
 			auto store = db.getStore(i % db.typeinfo.storeCount);

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -28,7 +28,7 @@ ArrayData& Array::getArray()
 	auto& id = getId();
 	if(id == 0) {
 		assert(typeinfo().propertyCount == 1);
-		id = store.arrayPool.add(typeinfo().propinfo[0]);
+		id = store.arrayPool.add(getItemType());
 	}
 	return store.arrayPool[id];
 }
@@ -36,13 +36,13 @@ ArrayData& Array::getArray()
 Property Array::getProperty(unsigned index)
 {
 	assert(typeinfo().propertyCount == 1);
-	return {getStore(), typeinfo().propinfo[0], getArray()[index]};
+	return {getStore(), getItemType(), getArray()[index]};
 }
 
 void Array::addNewItem(const char* value, size_t valueLength)
 {
 	assert(typeinfo().propertyCount == 1);
-	getStore().setValueString(typeinfo().propinfo[0], getArray().add(), value, valueLength);
+	getStore().setValueString(getItemType(), getArray().add(), value, valueLength);
 }
 
 } // namespace ConfigDB

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -33,15 +33,18 @@ ArrayData& Array::getArray()
 	return store.arrayPool[id];
 }
 
+const ArrayData& Array::getArray() const
+{
+	return getStore().arrayPool[getId()];
+}
+
 Property Array::getProperty(unsigned index)
 {
-	assert(typeinfo().propertyCount == 1);
 	return {getStore(), getItemType(), getArray()[index]};
 }
 
 void Array::addNewItem(const char* value, size_t valueLength)
 {
-	assert(typeinfo().propertyCount == 1);
 	getStore().setValueString(getItemType(), getArray().add(), value, valueLength);
 }
 

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -25,11 +25,12 @@ namespace ConfigDB
 ArrayData& Array::getArray()
 {
 	auto& store = getStore();
-	if(id() == 0) {
+	auto& id = getId();
+	if(id == 0) {
 		assert(typeinfo().propertyCount == 1);
-		*static_cast<ArrayId*>(data) = store.arrayPool.add(typeinfo().propinfo[0]);
+		id = store.arrayPool.add(typeinfo().propinfo[0]);
 	}
-	return store.arrayPool[id()];
+	return store.arrayPool[id];
 }
 
 Property Array::getProperty(unsigned index)

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -35,21 +35,14 @@ ArrayData& Array::getArray()
 
 Property Array::getProperty(unsigned index)
 {
-	auto& array = getArray();
-	if(index > array.getCount()) {
-		return {};
-	}
-	// Property info contains exactly one element
 	assert(typeinfo().propertyCount == 1);
-	return {getStore(), typeinfo().propinfo[0], array[index]};
+	return {getStore(), typeinfo().propinfo[0], getArray()[index]};
 }
 
 void Array::addNewItem(const char* value, size_t valueLength)
 {
 	assert(typeinfo().propertyCount == 1);
-	auto& array = getArray();
-	auto data = array[array.getCount()];
-	getStore().setValueString(typeinfo().propinfo[0], data, value, valueLength);
+	getStore().setValueString(typeinfo().propinfo[0], getArray().add(), value, valueLength);
 }
 
 } // namespace ConfigDB

--- a/src/ArrayBase.cpp
+++ b/src/ArrayBase.cpp
@@ -1,5 +1,5 @@
 /**
- * ConfigDB/ObjectArray.cpp
+ * ConfigDB/ArrayBase.cpp
  *
  * Copyright 2024 mikee47 <mike@sillyhouse.net>
  *
@@ -17,22 +17,26 @@
  *
  ****/
 
-#include "include/ConfigDB/ObjectArray.h"
+#include "include/ConfigDB/ArrayBase.h"
 #include "include/ConfigDB/Store.h"
 
 namespace ConfigDB
 {
-ArrayData& ObjectArray::getArray()
+ArrayData& ArrayBase::getArray()
 {
 	auto& store = getStore();
 	auto& id = getId();
 	if(id == 0) {
-		id = store.arrayPool.add(getItemType());
+		if(typeinfo().type == ObjectType::ObjectArray) {
+			id = store.arrayPool.add(*typeinfo().objinfo[0]);
+		} else {
+			id = store.arrayPool.add(typeinfo().propinfo[0]);
+		}
 	}
 	return store.arrayPool[id];
 }
 
-const ArrayData& ObjectArray::getArray() const
+const ArrayData& ArrayBase::getArray() const
 {
 	return getStore().arrayPool[getId()];
 }

--- a/src/Json/Store.cpp
+++ b/src/Json/Store.cpp
@@ -102,8 +102,7 @@ private:
 bool Store::load()
 {
 	auto& root = typeinfo();
-	assert(data && data == rootData.get());
-	memcpy_P(data, root.defaultData, root.structSize);
+	memcpy_P(rootData.get(), root.defaultData, root.structSize);
 	stringPool.clear();
 	arrayPool.clear();
 

--- a/src/Json/Store.cpp
+++ b/src/Json/Store.cpp
@@ -76,7 +76,9 @@ public:
 		}
 
 		if(parent.typeinfo().type == ObjectType::Array) {
-			static_cast<Array&>(parent).addNewItem(element.value, element.valueLength);
+			auto& array = static_cast<Array&>(parent);
+			auto propdata = store.parseString(array.getItemType(), element.value, element.valueLength);
+			array.addItem(&propdata);
 			return true;
 		}
 		auto prop = parent.findProperty(element.key, element.keyLength);

--- a/src/Json/Store.cpp
+++ b/src/Json/Store.cpp
@@ -104,7 +104,7 @@ private:
 bool Store::load()
 {
 	auto& root = typeinfo();
-	memcpy_P(rootData.get(), root.defaultData, root.structSize);
+	memcpy_P(getRootData(), root.defaultData, root.structSize);
 	stringPool.clear();
 	arrayPool.clear();
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -109,16 +109,12 @@ void* Object::getData()
 		return static_cast<Store*>(this)->getRootData();
 	}
 	switch(parent->typeinfo().type) {
-	case ObjectType::Store:
-	case ObjectType::Object:
-		return static_cast<uint8_t*>(parent->getData()) + dataRef;
 	case ObjectType::Array:
-		return static_cast<Array*>(parent)->getItemData(dataRef);
 	case ObjectType::ObjectArray:
-		return static_cast<ObjectArray*>(parent)->getItemData(dataRef);
+		return static_cast<ArrayBase*>(parent)->getItem(dataRef);
+	default:
+		return static_cast<uint8_t*>(parent->getData()) + dataRef;
 	}
-	assert(false);
-	return nullptr;
 }
 
 unsigned Object::getObjectCount() const

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -77,7 +77,7 @@ String ObjectInfo::getTypeDesc() const
 		s += toString(propinfo[0].type);
 		s += ']';
 	} else if(type == ObjectType::ObjectArray) {
-		s += "[]";
+		s += "[Object]";
 	}
 	return s;
 }

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -118,6 +118,7 @@ void* Object::getData()
 		return static_cast<ObjectArray*>(parent)->getItemData(dataRef);
 	}
 	assert(false);
+	return nullptr;
 }
 
 unsigned Object::getObjectCount() const

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -179,20 +179,29 @@ Database& Object::getDatabase()
 	return getStore().getDatabase();
 }
 
+String Object::getName() const
+{
+	if(parent && (parent->typeinfo().type == ObjectType::Array || parent->typeinfo().type == ObjectType::ObjectArray)) {
+		String path;
+		path += '[';
+		path += dataRef; // TODO: When items are deleted index will change, so use parent->getItemIndex(*this);
+		path += ']';
+		return path;
+	}
+	return typeinfo().name;
+}
+
 String Object::getPath() const
 {
-	String relpath;
-	for(auto typ = typeinfoPtr; typ->parent; typ = typ->parent) {
-		if(relpath) {
-			relpath += '.';
-		}
-		relpath += typ->name;
+	String path;
+	if(parent) {
+		path = parent->getPath();
 	}
-	String path = getStore().getName();
-	if(relpath) {
+	String name = getName();
+	if(path && name[0] != '[') {
 		path += '.';
-		path += relpath;
 	}
+	path += name;
 	return path;
 }
 

--- a/src/ObjectArray.cpp
+++ b/src/ObjectArray.cpp
@@ -32,17 +32,4 @@ ArrayData& ObjectArray::getArray()
 	return store.arrayPool[id];
 }
 
-Object ObjectArray::getObject(unsigned index)
-{
-	auto& array = getArray();
-	if(index > array.getCount()) {
-		return {};
-	}
-	auto& itemType = *typeinfo().objinfo[0];
-	if(index == array.getCount()) {
-		array.add(itemType);
-	}
-	return Object(itemType, this, index);
-}
-
 } // namespace ConfigDB

--- a/src/ObjectArray.cpp
+++ b/src/ObjectArray.cpp
@@ -25,10 +25,11 @@ namespace ConfigDB
 ArrayData& ObjectArray::getArray()
 {
 	auto& store = getStore();
-	if(id() == 0) {
-		*static_cast<ArrayId*>(data) = store.arrayPool.add(*typeinfo().objinfo[0]);
+	auto& id = getId();
+	if(id == 0) {
+		id = store.arrayPool.add(*typeinfo().objinfo[0]);
 	}
-	return store.arrayPool[id()];
+	return store.arrayPool[id];
 }
 
 Object ObjectArray::getObject(unsigned index)
@@ -38,8 +39,10 @@ Object ObjectArray::getObject(unsigned index)
 		return {};
 	}
 	auto& itemType = *typeinfo().objinfo[0];
-	auto itemData = (index < array.getCount()) ? array[index] : array.add(itemType);
-	return Object(itemType, this, itemData);
+	if(index == array.getCount()) {
+		array.add(itemType);
+	}
+	return Object(itemType, this, index);
 }
 
 } // namespace ConfigDB

--- a/src/ObjectArray.cpp
+++ b/src/ObjectArray.cpp
@@ -32,4 +32,9 @@ ArrayData& ObjectArray::getArray()
 	return store.arrayPool[id];
 }
 
+const ArrayData& ObjectArray::getArray() const
+{
+	return getStore().arrayPool[getId()];
+}
+
 } // namespace ConfigDB

--- a/src/ObjectArray.cpp
+++ b/src/ObjectArray.cpp
@@ -27,7 +27,7 @@ ArrayData& ObjectArray::getArray()
 	auto& store = getStore();
 	auto& id = getId();
 	if(id == 0) {
-		id = store.arrayPool.add(*typeinfo().objinfo[0]);
+		id = store.arrayPool.add(getItemType());
 	}
 	return store.arrayPool[id];
 }

--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -94,7 +94,7 @@ bool ArrayData::remove(unsigned index)
 	return false;
 }
 
-void* ArrayData::addItem(const void* data)
+void* ArrayData::add(const void* data)
 {
 	auto item = allocate(1);
 	if(!item) {

--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -88,17 +88,25 @@ bool ArrayData::remove(unsigned index)
 	if(index >= count) {
 		return false;
 	}
-	// TODO: How to mark item as deleted?
-	// memmove(getItemPtr(index), getItemPtr(index + 1), getItemSize(count - index - 1));
-	// deallocate(1);
-	return false;
+	if(index + 1 < count) {
+		memmove(getItemPtr(index), getItemPtr(index + 1), getItemSize(count - index - 1));
+	}
+	deallocate(1);
+	return true;
 }
 
-void* ArrayData::add(const void* data)
+void* ArrayData::insert(unsigned index, const void* data)
 {
-	auto item = allocate(1);
-	if(!item) {
+	assert(index <= count);
+	if(index > count) {
 		return nullptr;
+	}
+	if(!allocate(1)) {
+		return nullptr;
+	}
+	auto item = getItemPtr(index);
+	if(index + 1 < count) {
+		memmove(getItemPtr(index + 1), item, getItemSize(count - index - 1));
 	}
 	if(data) {
 		memcpy_P(item, data, itemSize);

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -66,7 +66,8 @@ bool Property::setValueString(const char* value, size_t valueLength)
 	if(!store) {
 		return false;
 	}
-	store->setValueString(*info, data, value, valueLength);
+	auto propdata = store->parseString(*info, value, valueLength);
+	memcpy(data, &propdata, info->getSize());
 	return true;
 }
 

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -90,8 +90,7 @@ void Store::setValueString(const PropertyInfo& prop, void* data, const char* val
 		if(prop.defaultValue && *prop.defaultValue == value) {
 			propdata.string = 0;
 		} else {
-			auto ref = stringPool.findOrAdd(value, valueLength);
-			propdata.string = ref;
+			propdata.string = stringPool.findOrAdd(value, valueLength);
 		}
 		break;
 	}

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -63,40 +63,31 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 	return nullptr;
 }
 
-void Store::setValueString(const PropertyInfo& prop, void* data, const char* value, size_t valueLength)
+PropertyData Store::parseString(const PropertyInfo& prop, const char* value, size_t valueLength)
 {
-	ConfigDB::PropertyData propdata{};
 	switch(prop.type) {
 	case PropertyType::Boolean:
-		propdata.b = (valueLength == 4) && memicmp(value, "true", 4) == 0;
-		break;
+		return {.b = (valueLength == 4) && memicmp(value, "true", 4) == 0};
 	case PropertyType::Int8:
 	case PropertyType::Int16:
 	case PropertyType::Int32:
-		propdata.int32 = strtol(value, nullptr, 0);
-		break;
+		return {.int32 = strtol(value, nullptr, 0)};
 	case PropertyType::Int64:
-		propdata.int32 = strtoll(value, nullptr, 0);
-		break;
+		return {.int64 = strtoll(value, nullptr, 0)};
 	case PropertyType::UInt8:
 	case PropertyType::UInt16:
 	case PropertyType::UInt32:
-		propdata.uint32 = strtoul(value, nullptr, 0);
-		break;
+		return {.uint32 = strtoul(value, nullptr, 0)};
 	case PropertyType::UInt64:
-		propdata.uint64 = strtoull(value, nullptr, 0);
-		break;
-	case PropertyType::String: {
+		return {.uint64 = strtoull(value, nullptr, 0)};
+	case PropertyType::String:
 		if(prop.defaultValue && *prop.defaultValue == value) {
-			propdata.string = 0;
-		} else {
-			propdata.string = stringPool.findOrAdd(value, valueLength);
+			return {.string = 0};
 		}
-		break;
-	}
+		return {.string = stringPool.findOrAdd(value, valueLength)};
 	}
 
-	memcpy(data, &propdata, prop.getSize());
+	return {};
 }
 
 size_t Store::printTo(Print& p, unsigned nesting) const

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -46,9 +46,19 @@ public:
 
 	void addNewItem(const char* value, size_t valueLength);
 
-	ArrayId id() const
+	ArrayId& getId()
 	{
-		return *static_cast<ArrayId*>(data);
+		return *static_cast<ArrayId*>(getData());
+	}
+
+	ArrayId getId() const
+	{
+		return const_cast<Array*>(this)->getId();
+	}
+
+	void* getItemData(ArrayId ref)
+	{
+		return getArray()[ref];
 	}
 
 protected:
@@ -73,7 +83,7 @@ public:
 	{
 	}
 
-	ArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, &parent, id)
+	ArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, &parent, dataRef)
 	{
 	}
 
@@ -91,11 +101,6 @@ public:
 	{
 		getArray().add(value);
 	}
-
-	void insertItem(unsigned index, ItemType value)
-	{
-		getArray().insert(index, value);
-	}
 };
 
 /**
@@ -110,7 +115,7 @@ public:
 	{
 	}
 
-	StringArrayTemplate(Object& parent, ArrayId* id) : Array(ClassType::typeinfo, &parent, id)
+	StringArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, &parent, dataRef)
 	{
 	}
 
@@ -129,12 +134,6 @@ public:
 	{
 		assert(typeinfo().propinfo[0].type == PropertyType::String);
 		getArray().add(getStringId(value));
-	}
-
-	void insertItem(unsigned index, const String& value)
-	{
-		assert(typeinfo().propinfo[0].type == PropertyType::String);
-		getArray().insert(index, getStringId(value));
 	}
 };
 

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -42,6 +42,11 @@ public:
 		return getArray().getCount();
 	}
 
+	unsigned getItemCount() const
+	{
+		return getPropertyCount();
+	}
+
 	Property getProperty(unsigned index);
 
 	void addNewItem(const char* value, size_t valueLength);
@@ -53,7 +58,7 @@ public:
 
 	ArrayId getId() const
 	{
-		return const_cast<Array*>(this)->getId();
+		return *static_cast<const ArrayId*>(getData());
 	}
 
 	void* getItemData(ArrayId ref)
@@ -94,7 +99,7 @@ public:
 
 	void setItem(unsigned index, ItemType value)
 	{
-		getArray().set(index, value);
+		*static_cast<ItemType*>(getArray()[index]) = value;
 	}
 
 	void addItem(ItemType value)
@@ -121,19 +126,45 @@ public:
 
 	String getItem(unsigned index) const
 	{
-		return static_cast<const char*>(getArray()[index]);
+		auto id = *static_cast<const StringId*>(getArray()[index]);
+		return getString(id);
 	}
 
 	void setItem(unsigned index, const String& value)
 	{
 		assert(typeinfo().propinfo[0].type == PropertyType::String);
-		getArray().set(index, getStringId(value));
+		*static_cast<StringId*>(getArray()[index]) = getStringId(value);
 	}
 
 	void addItem(const String& value)
 	{
-		assert(typeinfo().propinfo[0].type == PropertyType::String);
 		getArray().add(getStringId(value));
+	}
+
+	struct StringRef {
+		StringArrayTemplate& array;
+		unsigned index;
+
+		operator String() const
+		{
+			return array.getItem(index);
+		}
+
+		StringRef& operator=(const String& value)
+		{
+			array.setItem(index, value);
+			return *this;
+		}
+	};
+
+	StringRef operator[](unsigned index)
+	{
+		return StringRef{*this, index};
+	}
+
+	const String operator[](unsigned index) const
+	{
+		return getItem(index);
 	}
 };
 

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -95,6 +95,11 @@ public:
 		getArray().add(&value);
 	}
 
+	void insertItem(unsigned index, ItemType value)
+	{
+		getArray().insert(index, &value);
+	}
+
 	ItemRef operator[](unsigned index)
 	{
 		return {*this, index};
@@ -131,6 +136,12 @@ public:
 	{
 		auto stringId = this->getStringId(value);
 		this->getArray().add(&stringId);
+	}
+
+	void insertItem(unsigned index, const String& value)
+	{
+		auto stringId = this->getStringId(value);
+		this->getArray().insert(index, &stringId);
 	}
 };
 

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -34,7 +34,7 @@ public:
 
 	unsigned getPropertyCount() const
 	{
-		return getArray().getCount();
+		return getId() ? getArray().getCount() : 0;
 	}
 
 	unsigned getItemCount() const
@@ -68,17 +68,13 @@ public:
 
 	const PropertyInfo& getItemType() const
 	{
+		assert(typeinfo().propertyCount == 1);
 		return typeinfo().propinfo[0];
 	}
 
 protected:
 	ArrayData& getArray();
-
-	const ArrayData& getArray() const
-	{
-		// ArrayData will be created if it doesn't exist, but will be returned const to prevent updates
-		return const_cast<Array*>(this)->getArray();
-	}
+	const ArrayData& getArray() const;
 };
 
 /**

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -19,51 +19,26 @@
 
 #pragma once
 
-#include "Object.h"
-#include "Pool.h"
+#include "ArrayBase.h"
 
 namespace ConfigDB
 {
 /**
  * @brief Base class to provide array of properties
  */
-class Array : public Object
+class Array : public ArrayBase
 {
 public:
-	using Object::Object;
+	using ArrayBase::ArrayBase;
 
 	unsigned getPropertyCount() const
 	{
-		return getId() ? getArray().getCount() : 0;
+		return getItemCount();
 	}
 
-	unsigned getItemCount() const
+	Property getProperty(unsigned index)
 	{
-		return getPropertyCount();
-	}
-
-	Property getProperty(unsigned index);
-
-	void addNewItem(const char* value, size_t valueLength);
-
-	bool removeItem(unsigned index)
-	{
-		return getArray().remove(index);
-	}
-
-	ArrayId& getId()
-	{
-		return *static_cast<ArrayId*>(getData());
-	}
-
-	ArrayId getId() const
-	{
-		return *static_cast<const ArrayId*>(getData());
-	}
-
-	void* getItemData(ArrayId ref)
-	{
-		return getArray()[ref];
+		return {getStore(), getItemType(), getArray()[index]};
 	}
 
 	const PropertyInfo& getItemType() const
@@ -71,10 +46,6 @@ public:
 		assert(typeinfo().propertyCount == 1);
 		return typeinfo().propinfo[0];
 	}
-
-protected:
-	ArrayData& getArray();
-	const ArrayData& getArray() const;
 };
 
 /**
@@ -116,12 +87,12 @@ public:
 
 	void setItem(unsigned index, ItemType value)
 	{
-		*static_cast<ItemType*>(getArray()[index]) = value;
+		*static_cast<ItemType*>(ArrayBase::getItem(index)) = value;
 	}
 
 	void addItem(ItemType value)
 	{
-		getArray().add(value);
+		getArray().add(&value);
 	}
 
 	ItemRef operator[](unsigned index)
@@ -153,12 +124,13 @@ public:
 
 	void setItem(unsigned index, const String& value)
 	{
-		*static_cast<StringId*>(this->getArray()[index]) = this->getStringId(value);
+		*static_cast<StringId*>(ArrayBase::getItem(index)) = this->getStringId(value);
 	}
 
 	void addItem(const String& value)
 	{
-		this->getArray().add(this->getStringId(value));
+		auto stringId = this->getStringId(value);
+		this->getArray().add(&stringId);
 	}
 };
 

--- a/src/include/ConfigDB/ArrayBase.h
+++ b/src/include/ConfigDB/ArrayBase.h
@@ -42,16 +42,6 @@ public:
 		return getArray().remove(index);
 	}
 
-	ArrayId& getId()
-	{
-		return *static_cast<ArrayId*>(getData());
-	}
-
-	ArrayId getId() const
-	{
-		return *static_cast<const ArrayId*>(getData());
-	}
-
 	void* getItem(unsigned index)
 	{
 		return getArray()[index];
@@ -63,9 +53,18 @@ public:
 	}
 
 protected:
+	ArrayId& getId()
+	{
+		return *static_cast<ArrayId*>(getData());
+	}
+
+	ArrayId getId() const
+	{
+		return *static_cast<const ArrayId*>(getData());
+	}
+
 	ArrayData& getArray();
 	const ArrayData& getArray() const;
-	uint16_t newItem();
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/ArrayBase.h
+++ b/src/include/ConfigDB/ArrayBase.h
@@ -1,5 +1,5 @@
 /**
- * ConfigDB/Array.cpp
+ * ConfigDB/ArrayBase.h
  *
  * Copyright 2024 mikee47 <mike@sillyhouse.net>
  *
@@ -17,35 +17,55 @@
  *
  ****/
 
-#include "include/ConfigDB/Array.h"
-#include "include/ConfigDB/Store.h"
+#pragma once
+
+#include "Object.h"
+#include "Pool.h"
 
 namespace ConfigDB
 {
-ArrayData& Array::getArray()
+/**
+ * @brief Base class to provide array of properties
+ */
+class ArrayBase : public Object
 {
-	auto& store = getStore();
-	auto& id = getId();
-	if(id == 0) {
-		assert(typeinfo().propertyCount == 1);
-		id = store.arrayPool.add(getItemType());
+public:
+	using Object::Object;
+
+	unsigned getItemCount() const
+	{
+		return getId() ? getArray().getCount() : 0;
 	}
-	return store.arrayPool[id];
-}
 
-const ArrayData& Array::getArray() const
-{
-	return getStore().arrayPool[getId()];
-}
+	bool removeItem(unsigned index)
+	{
+		return getArray().remove(index);
+	}
 
-Property Array::getProperty(unsigned index)
-{
-	return {getStore(), getItemType(), getArray()[index]};
-}
+	ArrayId& getId()
+	{
+		return *static_cast<ArrayId*>(getData());
+	}
 
-void Array::addNewItem(const char* value, size_t valueLength)
-{
-	getStore().setValueString(getItemType(), getArray().add(), value, valueLength);
-}
+	ArrayId getId() const
+	{
+		return *static_cast<const ArrayId*>(getData());
+	}
+
+	void* getItem(unsigned index)
+	{
+		return getArray()[index];
+	}
+
+	void addItem(const void* value)
+	{
+		getArray().add(value);
+	}
+
+protected:
+	ArrayData& getArray();
+	const ArrayData& getArray() const;
+	uint16_t newItem();
+};
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -174,10 +174,7 @@ public:
 	 */
 	bool commit();
 
-	String getName() const
-	{
-		return typeinfo().name;
-	}
+	String getName() const;
 
 	String getPath() const;
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -99,7 +99,8 @@ public:
 
 	Object(const ObjectInfo& typeinfo, Store& store);
 
-	Object(const ObjectInfo& typeinfo, Object* parent, void* data) : typeinfoPtr(&typeinfo), parent(parent), data(data)
+	Object(const ObjectInfo& typeinfo, Object* parent, uint16_t dataRef)
+		: typeinfoPtr(&typeinfo), parent(parent), dataRef(dataRef)
 	{
 	}
 
@@ -179,6 +180,13 @@ public:
 		return *typeinfoPtr;
 	}
 
+	void* getData();
+
+	const void* getData() const
+	{
+		return const_cast<Object*>(this)->getData();
+	}
+
 protected:
 	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo);
 
@@ -193,7 +201,7 @@ protected:
 
 	const ObjectInfo* typeinfoPtr;
 	Object* parent{};
-	void* data{};
+	uint16_t dataRef{}; //< Relative to parent
 };
 
 /**
@@ -211,7 +219,7 @@ public:
 	{
 	}
 
-	ObjectTemplate(Object& parent, void* data) : Object(ClassType::typeinfo, &parent, data)
+	ObjectTemplate(Object& parent, uint16_t dataRef) : Object(ClassType::typeinfo, &parent, dataRef)
 	{
 	}
 };

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -46,13 +46,21 @@ String toString(ObjectType type);
 
 /**
  * @brief Identifies array storage within array pool
- * @note alignas(1) required as value contained in packed structures
+ * @note Can't just use uint16_t as it may be unaligned.
+ * Using `alignas` doesn't help.
  */
-#ifdef __clang__
-using ArrayId = uint16_t;
-#else
-using ArrayId alignas(1) = uint16_t;
-#endif
+struct __attribute__((packed)) ArrayId {
+	uint8_t value_[2];
+
+	constexpr ArrayId(uint16_t value = 0) : value_{uint8_t(value), uint8_t(value >> 8)}
+	{
+	}
+
+	constexpr operator uint16_t() const
+	{
+		return value_[0] | (value_[1] << 8);
+	}
+};
 
 struct ObjectInfo {
 	ObjectType type;

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -20,10 +20,7 @@
 #pragma once
 
 #include "Property.h"
-#include <Printable.h>
 #include <memory>
-
-#include <debug_progmem.h>
 
 #define CONFIGDB_OBJECT_TYPE_MAP(XX)                                                                                   \
 	XX(Store)                                                                                                          \
@@ -43,24 +40,6 @@ enum class ObjectType : uint32_t {
 };
 
 String toString(ObjectType type);
-
-/**
- * @brief Identifies array storage within array pool
- * @note Can't just use uint16_t as it may be unaligned.
- * Using `alignas` doesn't help.
- */
-struct __attribute__((packed)) ArrayId {
-	uint8_t value_[2];
-
-	constexpr ArrayId(uint16_t value = 0) : value_{uint8_t(value), uint8_t(value >> 8)}
-	{
-	}
-
-	constexpr operator uint16_t() const
-	{
-		return value_[0] | (value_[1] << 8);
-	}
-};
 
 struct ObjectInfo {
 	ObjectType type;

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -89,6 +89,12 @@ public:
 		array.add(ItemType::typeinfo.defaultData);
 		return ItemType(*this, ref);
 	}
+
+	ItemType insertItem(unsigned index)
+	{
+		getArray().insert(index, ItemType::typeinfo.defaultData);
+		return ItemType(*this, index);
+	}
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -36,23 +36,36 @@ public:
 
 	unsigned getObjectCount() const
 	{
-		return id() ? getArray().getCount() : 0;
+		return getId() ? getArray().getCount() : 0;
 	}
 
 	Object addItem()
 	{
 		auto& itemType = getItemType();
-		return Object(itemType, this, getArray().add(itemType));
+		auto& array = getArray();
+		auto ref = array.getCount();
+		array.add(itemType);
+		return Object(itemType, this, ref);
 	}
 
 	bool removeItem(unsigned index)
 	{
-		return id() && getArray().remove(index);
+		return getId() && getArray().remove(index);
 	}
 
-	ArrayId id() const
+	ArrayId& getId()
 	{
-		return *static_cast<ArrayId*>(data);
+		return *static_cast<ArrayId*>(getData());
+	}
+
+	ArrayId getId() const
+	{
+		return const_cast<ObjectArray*>(this)->getId();
+	}
+
+	void* getItemData(ArrayId ref)
+	{
+		return getArray()[ref];
 	}
 
 protected:
@@ -84,13 +97,13 @@ public:
 	{
 	}
 
-	ObjectArrayTemplate(Object& parent, void* data) : ObjectArray(ClassType::typeinfo, &parent, data)
+	ObjectArrayTemplate(Object& parent, uint16_t dataRef) : ObjectArray(ClassType::typeinfo, &parent, dataRef)
 	{
 	}
 
 	Item getItem(unsigned index)
 	{
-		return makeItem(getArray()[index]);
+		return Item(*this, index);
 	}
 
 	Item operator[](unsigned index)
@@ -100,18 +113,10 @@ public:
 
 	Item addItem()
 	{
-		return makeItem(getArray().add(Item::typeinfo));
-	}
-
-	Item insertItem(unsigned index)
-	{
-		return makeItem(getArray().insert(index, Item::typeinfo));
-	}
-
-private:
-	Item makeItem(void* itemData)
-	{
-		return Item(*this, *typename Item::Struct::Ptr(itemData));
+		auto& array = getArray();
+		uint16_t ref = array.getCount();
+		array.add(Item::typeinfo);
+		return Item(*this, ref);
 	}
 };
 

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -58,7 +58,7 @@ public:
 
 	bool removeItem(unsigned index)
 	{
-		return getId() && getArray().remove(index);
+		return getArray().remove(index);
 	}
 
 	ArrayId& getId()
@@ -68,7 +68,7 @@ public:
 
 	ArrayId getId() const
 	{
-		return const_cast<ObjectArray*>(this)->getId();
+		return *static_cast<const ArrayId*>(getData());
 	}
 
 	void* getItemData(ArrayId ref)
@@ -76,12 +76,12 @@ public:
 		return getArray()[ref];
 	}
 
-protected:
 	const ObjectInfo& getItemType() const
 	{
 		return *typeinfo().objinfo[0];
 	}
 
+protected:
 	ArrayData& getArray();
 
 	const ArrayData& getArray() const
@@ -99,8 +99,6 @@ protected:
 template <class ClassType, class ItemType> class ObjectArrayTemplate : public ObjectArray
 {
 public:
-	using Item = ItemType;
-
 	explicit ObjectArrayTemplate(Store& store) : ObjectArray(ClassType::typeinfo, store)
 	{
 	}
@@ -109,22 +107,22 @@ public:
 	{
 	}
 
-	Item getItem(unsigned index)
+	ItemType operator[](unsigned index)
 	{
-		return Item(*this, index);
+		return ItemType(*this, index);
 	}
 
-	Item operator[](unsigned index)
+	const ItemType operator[](unsigned index) const
 	{
-		return getItem(index);
+		return ItemType(*this, index);
 	}
 
-	Item addItem()
+	ItemType addItem()
 	{
 		auto& array = getArray();
-		uint16_t ref = array.getCount();
-		array.add(Item::typeinfo);
-		return Item(*this, ref);
+		auto ref = array.getCount();
+		array.add(ItemType::typeinfo);
+		return ItemType(*this, ref);
 	}
 };
 

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -85,9 +85,9 @@ public:
 	ItemType addItem()
 	{
 		auto& array = getArray();
-		auto ref = array.getCount();
+		auto index = array.getCount();
 		array.add(ItemType::typeinfo.defaultData);
-		return ItemType(*this, ref);
+		return ItemType(*this, index);
 	}
 
 	ItemType insertItem(unsigned index)

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -32,11 +32,19 @@ class ObjectArray : public Object
 public:
 	using Object::Object;
 
-	Object getObject(unsigned index);
+	Object getObject(unsigned index)
+	{
+		return Object(*typeinfo().objinfo[0], this, index);
+	}
 
 	unsigned getObjectCount() const
 	{
 		return getId() ? getArray().getCount() : 0;
+	}
+
+	unsigned getItemCount() const
+	{
+		return getObjectCount();
 	}
 
 	Object addItem()

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -19,32 +19,26 @@
 
 #pragma once
 
-#include "Object.h"
-#include "Pool.h"
+#include "ArrayBase.h"
 
 namespace ConfigDB
 {
 /**
  * @brief Base class to provide array of objects
  */
-class ObjectArray : public Object
+class ObjectArray : public ArrayBase
 {
 public:
-	using Object::Object;
+	using ArrayBase::ArrayBase;
 
 	Object getObject(unsigned index)
 	{
-		return Object(*typeinfo().objinfo[0], this, index);
+		return Object(getItemType(), this, index);
 	}
 
 	unsigned getObjectCount() const
 	{
-		return getId() ? getArray().getCount() : 0;
-	}
-
-	unsigned getItemCount() const
-	{
-		return getObjectCount();
+		return getItemCount();
 	}
 
 	Object addItem()
@@ -52,38 +46,14 @@ public:
 		auto& itemType = getItemType();
 		auto& array = getArray();
 		auto ref = array.getCount();
-		array.add(itemType);
+		array.add(itemType.defaultData);
 		return Object(itemType, this, ref);
-	}
-
-	bool removeItem(unsigned index)
-	{
-		return getArray().remove(index);
-	}
-
-	ArrayId& getId()
-	{
-		return *static_cast<ArrayId*>(getData());
-	}
-
-	ArrayId getId() const
-	{
-		return *static_cast<const ArrayId*>(getData());
-	}
-
-	void* getItemData(ArrayId ref)
-	{
-		return getArray()[ref];
 	}
 
 	const ObjectInfo& getItemType() const
 	{
 		return *typeinfo().objinfo[0];
 	}
-
-protected:
-	ArrayData& getArray();
-	const ArrayData& getArray() const;
 };
 
 /**
@@ -116,7 +86,7 @@ public:
 	{
 		auto& array = getArray();
 		auto ref = array.getCount();
-		array.add(ItemType::typeinfo);
+		array.add(ItemType::typeinfo.defaultData);
 		return ItemType(*this, ref);
 	}
 };

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -83,12 +83,7 @@ public:
 
 protected:
 	ArrayData& getArray();
-
-	const ArrayData& getArray() const
-	{
-		// ArrayData will be created if it doesn't exist, but will be returned const to prevent updates
-		return const_cast<ObjectArray*>(this)->getArray();
-	}
+	const ArrayData& getArray() const;
 };
 
 /**

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -74,17 +74,19 @@ protected:
 
 	void* getItemPtr(unsigned index)
 	{
+		assert(index < count);
 		return static_cast<uint8_t*>(buffer) + getItemSize(index);
 	}
 
 	const void* getItemPtr(unsigned index) const
 	{
+		assert(index < count);
 		return static_cast<const uint8_t*>(buffer) + getItemSize(index);
 	}
 
 	void* buffer{};
-	uint16_t count{};
-	uint8_t space{};
+	uint16_t count{0};
+	uint8_t space{0};
 	uint8_t itemSize;
 };
 
@@ -122,9 +124,7 @@ public:
 
 	const char* operator[](StringId ref) const
 	{
-		unsigned offset = ref - 1;
-		assert(offset < count);
-		return static_cast<const char*>(buffer) + offset;
+		return static_cast<const char*>(getItemPtr(ref - 1));
 	}
 
 	const char* getBuffer()
@@ -162,19 +162,6 @@ public:
 		return setItem(index, &value);
 	}
 
-	template <typename T>
-	typename std::enable_if<std::is_integral<T>::value, void*>::type insert(unsigned index, T value)
-	{
-		assert(itemSize == sizeof(T));
-		return insertItem(index, &value);
-	}
-
-	void* insert(unsigned index, const ObjectInfo& object)
-	{
-		assert(itemSize == object.structSize);
-		return insertItem(index, object.defaultData);
-	}
-
 	bool remove(unsigned index);
 
 	void* operator[](unsigned index)
@@ -190,16 +177,13 @@ public:
 
 	const void* operator[](unsigned index) const
 	{
+		assert(index < count);
 		return (index < count) ? getItemPtr(index) : nullptr;
 	}
 
 private:
-	void* addItem(const void* data)
-	{
-		return insertItem(count, data);
-	}
-	void* setItem(unsigned index, const void* data);
-	void* insertItem(unsigned index, const void* data);
+	void* addItem(const void* data);
+	// void* setItem(unsigned index, const void* data);
 };
 
 /**
@@ -231,16 +215,12 @@ public:
 
 	ArrayData& operator[](ArrayId id)
 	{
-		auto index = id - 1;
-		assert(index < count);
-		return *static_cast<ArrayData*>(getItemPtr(index));
+		return *static_cast<ArrayData*>(getItemPtr(id - 1));
 	}
 
 	const ArrayData& operator[](ArrayId id) const
 	{
-		auto index = id - 1;
-		assert(index < count);
-		return *static_cast<const ArrayData*>(getItemPtr(index));
+		return *static_cast<const ArrayData*>(getItemPtr(id - 1));
 	}
 
 	void clear();

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -154,27 +154,8 @@ class ArrayData : public PoolData
 public:
 	using PoolData::PoolData;
 
-	template <typename T> typename std::enable_if<std::is_integral<T>::value, void*>::type add(T value)
-	{
-		assert(itemSize == sizeof(T));
-		return addItem(&value);
-	}
-
-	void* add(const ObjectInfo& object)
-	{
-		assert(itemSize == object.structSize);
-		return addItem(object.defaultData);
-	}
-
-	void* add()
-	{
-		return addItem(nullptr);
-	}
-
+	void* add(const void* value = nullptr);
 	bool remove(unsigned index);
-
-private:
-	void* addItem(const void* data);
 };
 
 /**

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -56,6 +56,16 @@ public:
 		return count * itemSize;
 	}
 
+	void* operator[](unsigned index)
+	{
+		return getItemPtr(index);
+	}
+
+	const void* operator[](unsigned index) const
+	{
+		return getItemPtr(index);
+	}
+
 	void clear()
 	{
 		free(buffer);
@@ -156,34 +166,15 @@ public:
 		return addItem(object.defaultData);
 	}
 
-	template <typename T> typename std::enable_if<std::is_integral<T>::value, void*>::type set(unsigned index, T value)
+	void* add()
 	{
-		assert(itemSize == sizeof(T));
-		return setItem(index, &value);
+		return addItem(nullptr);
 	}
 
 	bool remove(unsigned index);
 
-	void* operator[](unsigned index)
-	{
-		if(index == count) {
-			return addItem(nullptr);
-		}
-		if(index < count) {
-			return getItemPtr(index);
-		}
-		return nullptr;
-	}
-
-	const void* operator[](unsigned index) const
-	{
-		assert(index < count);
-		return (index < count) ? getItemPtr(index) : nullptr;
-	}
-
 private:
 	void* addItem(const void* data);
-	// void* setItem(unsigned index, const void* data);
 };
 
 /**

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -154,7 +154,13 @@ class ArrayData : public PoolData
 public:
 	using PoolData::PoolData;
 
-	void* add(const void* value = nullptr);
+	void* insert(unsigned index, const void* value = nullptr);
+
+	void* add(const void* value = nullptr)
+	{
+		return insert(getCount(), value);
+	}
+
 	bool remove(unsigned index);
 };
 

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -165,6 +165,24 @@ public:
 };
 
 /**
+ * @brief Identifies array storage within array pool
+ * @note Can't just use uint16_t as it may be unaligned.
+ * Using `alignas` doesn't help.
+ */
+struct __attribute__((packed)) ArrayId {
+	uint8_t value_[2];
+
+	constexpr ArrayId(uint16_t value = 0) : value_{uint8_t(value), uint8_t(value >> 8)}
+	{
+	}
+
+	constexpr operator uint16_t() const
+	{
+		return value_[0] | (value_[1] << 8);
+	}
+};
+
+/**
  * @brief This pool stores array data
  *
  * An array has fixed-size items.

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -87,11 +87,11 @@ union __attribute__((packed)) PropertyData {
 	uint8_t uint8;
 	uint16_t uint16;
 	uint32_t uint32;
-	uint16_t uint64;
+	uint64_t uint64;
 	int8_t int8;
 	int16_t int16;
 	int32_t int32;
-	int16_t int64;
+	int64_t int64;
 	bool b;
 	float f;
 	StringId string;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -52,7 +52,6 @@ public:
 	Store(Database& db, const ObjectInfo& typeinfo)
 		: Object(typeinfo), db(db), rootData(std::make_unique<uint8_t[]>(typeinfo.structSize))
 	{
-		Object::data = rootData.get();
 	}
 
 	String getFileName() const
@@ -68,13 +67,18 @@ public:
 		return db;
 	}
 
-	void* getObjectDataPtr(const ObjectInfo& object)
+	uint16_t getObjectDataRef(const ObjectInfo& object)
 	{
 		size_t offset{0};
 		for(auto obj = &object; obj; obj = obj->parent) {
 			offset += obj->getOffset();
 		}
-		return rootData.get() + offset;
+		return offset;
+	}
+
+	uint8_t* getRootData()
+	{
+		return rootData.get();
 	}
 
 	/**

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -116,7 +116,7 @@ public:
 	}
 
 	String getValueString(const PropertyInfo& info, const void* data) const;
-	void setValueString(const PropertyInfo& prop, void* data, const char* value, size_t valueLength);
+	PropertyData parseString(const PropertyInfo& prop, const char* value, size_t valueLength);
 
 	ArrayPool arrayPool;
 	StringPool stringPool;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -121,7 +121,7 @@ public:
 	ArrayPool arrayPool;
 	StringPool stringPool;
 
-protected:
+private:
 	Database& db;
 	std::unique_ptr<uint8_t[]> rootData;
 };

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -536,7 +536,7 @@ def generate_object_struct(obj: Object) -> CodeLines:
 
     return CodeLines([
         '',
-        'struct __attribute((packed)) Struct {',
+        'struct __attribute__((packed)) Struct {',
         [
             'using Ptr = Struct*;',
             '',

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -560,12 +560,12 @@ def generate_property_accessors(obj: Object) -> list:
         '',
         f'{prop.ctype} get{prop.typename}() const',
         '{',
-        ['return ' + ('getString(' if prop.ptype == 'string' else '(') + f'Struct::Ptr(data)->{prop.id});'],
+        ['return ' + ('getString(' if prop.ptype == 'string' else '(') + f'Struct::Ptr(getData())->{prop.id});'],
         '}',
         '',
         f'void set{prop.typename}({prop.ctype_constref} value)',
         '{',
-        [f'Struct::Ptr(data)->{prop.id} = ' + ('getStringId(value);' if prop.ptype == 'string' else 'value;')],
+        [f'Struct::Ptr(getData())->{prop.id} = ' + ('getStringId(value);' if prop.ptype == 'string' else 'value;')],
         '}'
         ) for prop in obj.properties)]
 
@@ -632,10 +632,10 @@ def generate_contained_constructors(obj: Object) -> list:
     if obj.is_item:
         return [
             '',
-            f'{obj.typename}(ConfigDB::{obj.parent.base_class}& {obj.parent.id}, Struct& data):',
+            f'{obj.typename}(ConfigDB::{obj.parent.base_class}& {obj.parent.id}, uint16_t dataRef):',
             [', '.join([
-                f'{obj.classname}Template({obj.parent.id}, &data)',
-                *(f'{child.id}(*this, data.{child.id})' for child in obj.children)
+                f'{obj.classname}Template({obj.parent.id}, dataRef)',
+                *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
             ])],
             '{',
             '}',
@@ -647,19 +647,18 @@ def generate_contained_constructors(obj: Object) -> list:
             '',
             f'{obj.typename_contained}(ConfigDB::Store& store): ' + ', '.join([
                 f'{obj.base_class}Template(store)',
-                *(f'{child.id}(*this, Struct::Ptr(data)->{child.id})' for child in obj.children)
+                *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
             ]),
             '{',
             '}',
         ]
 
     if not obj.is_root:
-        data_type = 'ConfigDB::ArrayId' if obj.is_array else 'Struct'
         headers += [
             '',
-            f'{obj.typename_contained}({obj.parent.typename_contained}& parent, {data_type}& data): ' + ', '.join([
-                f'{obj.base_class}Template(parent, &data)',
-                *(f'{child.id}(*this, data.{child.id})' for child in obj.children)
+            f'{obj.typename_contained}({obj.parent.typename_contained}& parent, uint16_t dataRef): ' + ', '.join([
+                f'{obj.base_class}Template(parent, dataRef)',
+                *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
             ]),
             '{',
             '}',


### PR DESCRIPTION
Keeping pointers in Object gets broken when array memory reallocated.
This PR fixes that by changing to a 16-bit 'reference' value which parent resolves to pointer as required. For structures this is just an offset in the parent structure, for arrays, it's an index.

There doesn't seem to be any way to tell the compiler that `ArrayId` can be misaligned. This causes problems on the Esp8266. So this is now defined as a packed struct. Note that we could just define it as `uint8_t` as we probably don't need more than 255 items, but no real need to restrict array sizes for those devices with lots of RAM.

Arrays have been simplified and the `ArrayBase` class added as a base for both Array and ObjectArray.

Insertion and deletion supported, plus operator[] for both read/write.
