### PR TITLE
Store counted strings in StringPool

### DIFF
--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -137,7 +137,7 @@ void printStringPool(const ConfigDB::StringPool& pool, bool detailed)
 	}
 
 	unsigned i = 0;
-	for(unsigned id = 1; auto string = pool[id];) {
+	for(unsigned id = 1; auto string = pool[id]; ++i) {
 		String tag;
 		tag += "    #";
 		tag.concat(i, DEC, 2, ' ');
@@ -246,7 +246,7 @@ void init()
 
 	Serial << endl << endl;
 
-	printStoreStats(database, false);
+	printStoreStats(database, true);
 
 	statTimer.initializeMs<5000>([]() {
 		printHeap();

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -135,17 +135,19 @@ void printStringPool(const ConfigDB::StringPool& pool, bool detailed)
 		return;
 	}
 
-	auto start = pool.getBuffer();
-	auto end = start + pool.getCount();
 	unsigned i = 0;
-	for(auto s = start; s < end; ++i, s += strlen(s) + 1) {
+	for(unsigned id = 1; auto string = pool[id];) {
 		String tag;
 		tag += "    #";
 		tag.concat(i, DEC, 2, ' ');
 		tag += " [";
-		tag += s - start;
+		tag += id;
 		tag += ']';
-		Serial << tag.pad(18) << ": \"" << s << '"' << endl;
+		String s(string);
+		Format::json.escape(s);
+		Format::json.quote(s);
+		Serial << tag.pad(18) << ": " << s << endl;
+		id += string.getStorageSize();
 	}
 }
 

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -4,6 +4,7 @@
 #include <basic-config.h>
 #include <ConfigDB/Json/Reader.h>
 #include <Data/CStringArray.h>
+#include <Data/Format/Json.h>
 
 #ifdef ENABLE_MALLOC_COUNT
 #include <malloc_count.h>

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -145,12 +145,12 @@ String Object::getPath() const
 
 String Object::getString(StringId id) const
 {
-	return getStore().stringPool[id];
+	return String(getStore().stringPool[id]);
 }
 
-StringId Object::getStringId(const char* value, size_t valueLength)
+StringId Object::getStringId(const char* value, uint16_t valueLength)
 {
-	return getStore().stringPool.findOrAdd(value, valueLength);
+	return getStore().stringPool.findOrAdd({value, valueLength});
 }
 
 unsigned Object::getPropertyCount() const

--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -72,7 +72,7 @@ StringId StringPool::find(const CountedString& string) const
 		if(string == cs) {
 			return 1 + offset;
 		}
-		offset += cs.length;
+		offset += cs.getStorageSize();
 	}
 	return 0;
 }

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -61,7 +61,7 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 		return String(propData.uint64);
 	case PropertyType::String:
 		if(propData.string) {
-			return stringPool[propData.string];
+			return String(stringPool[propData.string]);
 		}
 		if(info.defaultValue) {
 			return *info.defaultValue;
@@ -71,7 +71,7 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 	return nullptr;
 }
 
-PropertyData Store::parseString(const PropertyInfo& prop, const char* value, size_t valueLength)
+PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uint16_t valueLength)
 {
 	switch(prop.type) {
 	case PropertyType::Boolean:
@@ -92,7 +92,7 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, siz
 		if(prop.defaultValue && *prop.defaultValue == value) {
 			return {.string = 0};
 		}
-		return {.string = stringPool.findOrAdd(value, valueLength)};
+		return {.string = stringPool.findOrAdd({value, valueLength})};
 	}
 
 	return {};

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -152,7 +152,7 @@ protected:
 
 	String getString(StringId id) const;
 
-	StringId getStringId(const char* value, size_t valueLength);
+	StringId getStringId(const char* value, uint16_t valueLength);
 
 	StringId getStringId(const String& value)
 	{

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -82,7 +82,7 @@ public:
 	void clear();
 
 	String getValueString(const PropertyInfo& info, const void* data) const;
-	PropertyData parseString(const PropertyInfo& prop, const char* value, size_t valueLength);
+	PropertyData parseString(const PropertyInfo& prop, const char* value, uint16_t valueLength);
 
 	const StringPool& getStringPool() const
 	{


### PR DESCRIPTION
The `StringPool` storage currently stores string items as a sequence of NUL-terminated C-strings, identified by a `StringId` type which represents the starting offset for the value.

The main disadvantage of this is that it cannot accommodate binary data. This PR updates the pool to use counted strings instead. It adds `CountedString` to manage instances, with the length encoded in a prefix of one or two bytes.

A quick test shows that `JsonStreamingParser` can only handle a limited set of single-character escapes, such as `\n`, so requires updating to handle escapes such as `\0` or `\xfe`.