### PR TITLE
Implement store sharing / locking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,3 +86,46 @@ A :cpp:class:`ConfigDB::Writer` instance has various methods for de-serialising 
 Currently only **json** is implemented - see :cpp:namespace:`ConfigDB::Json`.
 Each store is contained in a separate file.
 The name of the store forms the JSONPath prefix for any contained objects and values.
+
+The :sample:`BasicConfig` sample demonstrates using the stream classes to read and write data from a web client.
+
+.. highlight: JSON
+
+.. note::
+
+    Current streaming update (writing) behaviour is to overwrite only those values received.
+    This allows selective updating of properties. For example::
+
+        {
+          "security": {
+            "api_secured": "false"
+          }
+        }
+
+    This updates one value in the database, leaving everything else unchanged.
+
+    Arrays are overwritten entirely::
+
+        {
+          "general": {
+            "supported_color_models": [
+              "RGB",
+              "RAW"
+            ]
+          }
+        }
+
+    replaces everything in *general.supported_color_models*, and this::
+
+        {
+          "general": {
+            "channels": [
+              {
+                "pin": 1,
+                "name": "dummy"
+              }
+            ]
+          }
+        }
+
+    Deletes all existing entries in *general.channels* and replaces it with the one object provided.

--- a/README.rst
+++ b/README.rst
@@ -129,3 +129,58 @@ The :sample:`BasicConfig` sample demonstrates using the stream classes to read a
         }
 
     Deletes all existing entries in *general.channels* and replaces it with the one object provided.
+
+
+C++ API code generation
+-----------------------
+
+Each *.cfgdb* file found in the project directory is compiled into a corresponding *.h* and *.cpp* file in *out/ConfigDB*.
+This directory is added to the *#include* path.
+
+For example:
+
+- *basic-config.cfgdb* is compiled into *basic-config.h* and *basic-config.cpp*
+- The applications will *#include <basic-config.h>*
+- This file contains defines the `BasicConfig` class which contains all accessible objects and array items
+- Each object defined in the schema, such as *network*, gets a corresponding *contained* class such as `ContainedNetwork`, and an *outer* class such as `Network`.
+- Both of these classes provide *read-only* access to the data via `getXXX` methods.
+- Outer classes contain a `shared_ptr<Store>`, whereas contained classes do not (they obtain the store from their parent object).
+- Application code can instantiate the *outer* class directly `BasicConfig::Network network(database);`
+- Child objects within classes are defined as member variables, such as `network.mqtt`, which is a `ContainedMqtt` class instance.
+- A third *updater* class type is also generated which adds `setXXX` methods for changing values.
+- Only one *updater* per store can be open at a time. This ensures consistent data updates.
+
+
+Updaters
+--------
+
+.. highlight: c++
+
+Code can update database entries in several ways.
+
+1. Using updater created on read-only class::
+
+      BasicConfig::Root::Security sec(database);
+      if(auto update = sec.update()) {
+        update.setApiSecured(true);
+      }
+
+  The `update` value is a `BasicConfig::Root::Security::Updater` instance.
+
+2. Directly instantiate updater class::
+
+      if(auto update = BasicConfig::Root::Security::Updater(database)) {
+        update.setApiSecured(true);
+      }
+
+  This form is more direct.
+
+3. Asynchronous update::
+
+      BasicConfig::Root::Security sec(database);
+      bool completed = sec.update([](auto update) {
+        update.setApiSecured(true);
+      });
+
+    If there are no other updates in progress then the update happens immediately and `completed` is `true`.
+    Otherwise the update is queued and `false` is returned. The update will be executed when the store is released.

--- a/samples/Basic_Config/README.rst
+++ b/samples/Basic_Config/README.rst
@@ -20,3 +20,13 @@ Then do some editing:
 
 - Open the .cfgdb file in vscode and associate with JSON format (hit *F1* then *change language mode*)
 - Add ``"store": "json"`` values to the root, *general*, *color* and *events* objects.
+
+
+Web client
+----------
+
+The sample starts a basic HTTP server which can be visited to view the database content in JSON format.
+
+An HTTP POST request can also be used to update the database contents.
+This must have `Content-Type: application/json` encoding.
+For example, send `{"security":{"api_secured":"false"}}` to update a single value.

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -48,67 +48,67 @@ SimpleTimer statTimer;
 
 	{
 		BasicConfig::Root::Security sec(database);
-		sec.setApiSecured(true);
-		sec.commit();
+		if(auto update = sec.beginUpdate()) {
+			update.setApiSecured(true);
+		}
 	}
 
-	{
-		BasicConfig::General general(database);
-		general.setDeviceName(F("Test Device #") + os_random());
-		Serial << general.getPath() << ".deviceName = " << general.getDeviceName() << endl;
-		general.commit();
-	}
+	// {
+	// 	BasicConfig::General general(database);
+	// 	general.setDeviceName(F("Test Device #") + os_random());
+	// 	Serial << general.getPath() << ".deviceName = " << general.getDeviceName() << endl;
+	// 	general.commit();
+	// }
 
 	{
 		BasicConfig::Color color(database);
-		color.colortemp.setWw(12);
+		auto update = color.beginUpdate();
+		update.colortemp.setWw(12);
 		Serial << color.colortemp.getPath() << ".WW = " << color.colortemp.getWw() << endl;
 
 		BasicConfig::Color::Brightness bri(database);
-		bri.setBlue(12);
+		update.brightness.setBlue(12);
 		Serial << bri.getPath() << ".Blue = " << bri.getBlue() << endl;
-
-		color.commit();
 	}
 
-	{
-		BasicConfig::Events events(database);
-		events.setColorMinintervalMs(1200);
-		events.commit();
-	}
+	// {
+	// 	BasicConfig::Events events(database);
+	// 	events.setColorMinintervalMs(1200);
+	// 	events.commit();
+	// }
 
-	{
-		BasicConfig::General::Channels channels(database);
-		auto item = channels.addItem();
-		item.setName(F("Channel #") + os_random());
-		item.setPin(12);
-		item.details.setCurrentLimit(400);
-		item.notes.addItem(_F("This is a nice pin"));
-		item.notes.addItem(_F("It is useful"));
-		item.notes.addItem(SystemClock.getSystemTimeString());
-		for(unsigned i = 0; i < 16; ++i) {
-			item.values.addItem(os_random());
-		}
+	// {
+	// 	BasicConfig::General::Channels channels(database);
+	// 	auto item = channels.addItem();
+	// 	item.setName(F("Channel #") + os_random());
+	// 	item.setPin(12);
+	// 	item.details.setCurrentLimit(400);
+	// 	item.notes.addItem(_F("This is a nice pin"));
+	// 	item.notes.addItem(_F("It is useful"));
+	// 	item.notes.addItem(SystemClock.getSystemTimeString());
+	// 	for(unsigned i = 0; i < 16; ++i) {
+	// 		item.values.addItem(os_random());
+	// 	}
 
-		Serial << "old note = " << item.notes[0] << endl;
-		item.notes[0] = F("Overwriting nice pin");
-		Serial << "new note = " << item.notes[0] << endl;
-		assert(String(item.notes[0]) == F("Overwriting nice pin"));
+	// 	Serial << "old note = " << item.notes[0] << endl;
+	// 	item.notes[0] = F("Overwriting nice pin");
+	// 	Serial << "new note = " << item.notes[0] << endl;
+	// 	assert(String(item.notes[0]) == F("Overwriting nice pin"));
 
-		item.notes.insertItem(0, F("Inserted at #0 on ") + SystemClock.getSystemTimeString());
-		item.notes.insertItem(2, F("Inserted at #2"));
+	// 	item.notes.insertItem(0, F("Inserted at #0 on ") + SystemClock.getSystemTimeString());
+	// 	item.notes.insertItem(2, F("Inserted at #2"));
 
-		item.commit();
-		Serial << channels.getPath() << " = " << item << endl;
-	}
+	// 	item.commit();
+	// 	Serial << channels.getPath() << " = " << item << endl;
+	// }
 
-	{
-		BasicConfig::General::SupportedColorModels models(database);
-		models.addItem(F("New Model #") + os_random());
-		models.insertItem(0, F("Inserted at #0"));
-		models.commit();
-		Serial << models.getPath() << " = " << models << endl;
-	}
+	// {
+	// 	BasicConfig::General::SupportedColorModels models(database);
+	// 	models.addItem(F("New Model #") + os_random());
+	// 	models.insertItem(0, F("Inserted at #0"));
+	// 	models.commit();
+	// 	Serial << models.getPath() << " = " << models << endl;
+	// }
 }
 
 /*

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -177,7 +177,7 @@ void printArrayPool(const ConfigDB::ArrayPool& pool, bool detailed)
 
 void printStoreStats(ConfigDB::Database& db, bool detailed)
 {
-	for(unsigned i = 0; auto store = db.getStore(i); ++i) {
+	for(unsigned i = 0; auto store = db.openStore(i); ++i) {
 		Serial << F("Store '") << store->getName() << "':" << endl;
 		Serial << F("  Root: ") << store->typeinfo().structSize << endl;
 		printStringPool(store->getStringPool(), detailed);

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -77,7 +77,7 @@ SimpleTimer statTimer;
 			.blue = 8,
 		};
 		auto async = BasicConfig::Color::Brightness(database).update(
-			[values](BasicConfig::Color::ContainedBrightness::Updater upd) {
+			[values](BasicConfig::Color::Brightness::Updater upd) {
 				Serial << "ASYNC UPDATE" << endl;
 				upd.setRed(values.red);
 				upd.setGreen(values.green);

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -177,7 +177,8 @@ void printArrayPool(const ConfigDB::ArrayPool& pool, bool detailed)
 
 void printStoreStats(ConfigDB::Database& db, bool detailed)
 {
-	for(unsigned i = 0; auto store = db.openStore(i); ++i) {
+	for(unsigned i = 0; i < db.typeinfo.storeCount; ++i) {
+		auto store = db.openStore(i);
 		Serial << F("Store '") << store->getName() << "':" << endl;
 		Serial << F("  Root: ") << store->typeinfo().structSize << endl;
 		printStringPool(store->getStringPool(), detailed);

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -69,6 +69,21 @@ SimpleTimer statTimer;
 		BasicConfig::Color::Brightness bri(database);
 		update.brightness.setBlue(12);
 		Serial << bri.getPath() << ".Blue = " << bri.getBlue() << endl;
+
+		// OK, since we have an update in progress let's try another one asynchronously
+		BasicConfig::Color::Brightness::Struct values{
+			.red = 12,
+			.green = 44,
+			.blue = 8,
+		};
+		auto async = BasicConfig::Color::Brightness(database).update(
+			[values](BasicConfig::Color::ContainedBrightness::Updater upd) {
+				Serial << "ASYNC UPDATE" << endl;
+				upd.setRed(values.red);
+				upd.setGreen(values.green);
+				upd.setBlue(values.blue);
+			});
+		Serial << F("Async update ") << (async ? "completed" : "pending") << endl;
 	}
 
 	// {

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -48,7 +48,7 @@ SimpleTimer statTimer;
 
 	{
 		BasicConfig::Root::Security sec(database);
-		if(auto update = sec.beginUpdate()) {
+		if(auto update = sec.update()) {
 			update.setApiSecured(true);
 		}
 	}
@@ -62,7 +62,7 @@ SimpleTimer statTimer;
 
 	{
 		BasicConfig::Color color(database);
-		auto update = color.beginUpdate();
+		auto update = color.update();
 		update.colortemp.setWw(12);
 		Serial << color.colortemp.getPath() << ".WW = " << color.colortemp.getWw() << endl;
 

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -55,12 +55,11 @@ SimpleTimer statTimer;
 		}
 	}
 
-	// {
-	// 	BasicConfig::General general(database);
-	// 	general.setDeviceName(F("Test Device #") + os_random());
-	// 	Serial << general.getPath() << ".deviceName = " << general.getDeviceName() << endl;
-	// 	general.commit();
-	// }
+	{
+		BasicConfig::General::OuterUpdater general(database);
+		general.setDeviceName(F("Test Device #") + os_random());
+		Serial << general.getPath() << ".deviceName = " << general.getDeviceName() << endl;
+	}
 
 	{
 		BasicConfig::Color color(database);
@@ -68,7 +67,7 @@ SimpleTimer statTimer;
 		update.colortemp.setWw(12);
 		Serial << color.colortemp.getPath() << ".WW = " << color.colortemp.getWw() << endl;
 
-		BasicConfig::Color::Brightness bri(database);
+		auto& bri = color.brightness;
 		update.brightness.setBlue(12);
 		Serial << bri.getPath() << ".Blue = " << bri.getBlue() << endl;
 
@@ -88,44 +87,41 @@ SimpleTimer statTimer;
 		Serial << F("Async update ") << (async ? "completed" : "pending") << endl;
 	}
 
-	// {
-	// 	BasicConfig::Events events(database);
-	// 	events.setColorMinintervalMs(1200);
-	// 	events.commit();
-	// }
+	{
+		BasicConfig::Events::OuterUpdater events(database);
+		events.setColorMinintervalMs(1200);
+	}
 
-	// {
-	// 	BasicConfig::General::Channels channels(database);
-	// 	auto item = channels.addItem();
-	// 	item.setName(F("Channel #") + os_random());
-	// 	item.setPin(12);
-	// 	item.details.setCurrentLimit(400);
-	// 	item.notes.addItem(_F("This is a nice pin"));
-	// 	item.notes.addItem(_F("It is useful"));
-	// 	item.notes.addItem(SystemClock.getSystemTimeString());
-	// 	for(unsigned i = 0; i < 16; ++i) {
-	// 		item.values.addItem(os_random());
-	// 	}
+	{
+		BasicConfig::General::Channels::OuterUpdater channels(database);
+		auto item = channels.addItem();
+		item.setName(F("Channel #") + os_random());
+		item.setPin(12);
+		item.details.setCurrentLimit(400);
+		item.notes.addItem(_F("This is a nice pin"));
+		item.notes.addItem(_F("It is useful"));
+		item.notes.addItem(SystemClock.getSystemTimeString());
+		for(unsigned i = 0; i < 16; ++i) {
+			item.values.addItem(os_random());
+		}
 
-	// 	Serial << "old note = " << item.notes[0] << endl;
-	// 	item.notes[0] = F("Overwriting nice pin");
-	// 	Serial << "new note = " << item.notes[0] << endl;
-	// 	assert(String(item.notes[0]) == F("Overwriting nice pin"));
+		Serial << "old note = " << item.notes[0] << endl;
+		item.notes[0] = F("Overwriting nice pin");
+		Serial << "new note = " << item.notes[0] << endl;
+		assert(String(item.notes[0]) == F("Overwriting nice pin"));
 
-	// 	item.notes.insertItem(0, F("Inserted at #0 on ") + SystemClock.getSystemTimeString());
-	// 	item.notes.insertItem(2, F("Inserted at #2"));
+		item.notes.insertItem(0, F("Inserted at #0 on ") + SystemClock.getSystemTimeString());
+		item.notes.insertItem(2, F("Inserted at #2"));
 
-	// 	item.commit();
-	// 	Serial << channels.getPath() << " = " << item << endl;
-	// }
+		Serial << channels.getPath() << " = " << item << endl;
+	}
 
-	// {
-	// 	BasicConfig::General::SupportedColorModels models(database);
-	// 	models.addItem(F("New Model #") + os_random());
-	// 	models.insertItem(0, F("Inserted at #0"));
-	// 	models.commit();
-	// 	Serial << models.getPath() << " = " << models << endl;
-	// }
+	{
+		BasicConfig::General::SupportedColorModels::OuterUpdater models(database);
+		models.addItem(F("New Model #") + os_random());
+		models.insertItem(0, F("Inserted at #0"));
+		Serial << models.getPath() << " = " << models << endl;
+	}
 }
 
 /*

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -5,17 +5,14 @@
 
 namespace
 {
-void __noinline testSetValue(BasicConfig& db, int value, bool commit)
+void __noinline testSetValue(BasicConfig& db, int value)
 {
-	BasicConfig::Color::Brightness bri(db);
+	BasicConfig::Color::Brightness::Updater bri(db);
 	bri.setRed(value);
 	bri.setGreen(value);
 	bri.setBlue(value);
 	bri.setWw(value);
 	bri.setCw(value);
-	if(commit) {
-		bri.commit();
-	}
 }
 
 void __noinline testGetValueSimple(BasicConfig& db)
@@ -98,20 +95,10 @@ void checkPerformance(BasicConfig& db)
 
 	Serial << _F("Evaluating setValue / commit ...") << endl;
 	{
-		Profiling::MicroTimes times(F("Set Value only"));
-		for(int i = 0; i < rounds; i++) {
-			times.start();
-			testSetValue(db, i, false);
-			times.update();
-		}
-		Serial << times << endl;
-	}
-
-	{
 		Profiling::MicroTimes times(F("Set Value + commit"));
 		for(int i = 0; i < rounds; i++) {
 			times.start();
-			testSetValue(db, i, true);
+			testSetValue(db, i);
 			times.update();
 		}
 		Serial << times << endl;

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -70,7 +70,7 @@ void checkPerformance(BasicConfig& db)
 		Profiling::MicroTimes times(F("Verify load caching"));
 		for(int i = 0; i < rounds; i++) {
 			times.start();
-			db.getStore(1);
+			db.openStore(1);
 			times.update();
 		}
 		Serial << times << endl;
@@ -81,7 +81,7 @@ void checkPerformance(BasicConfig& db)
 		Profiling::MicroTimes times(F("Load all stores"));
 		for(int i = 0; i < rounds; i++) {
 			times.start();
-			auto store = db.getStore(i % db.typeinfo.storeCount);
+			auto store = db.openStore(i % db.typeinfo.storeCount);
 			times.update();
 		}
 		Serial << times << endl;

--- a/samples/Basic_Config/app/performance.cpp
+++ b/samples/Basic_Config/app/performance.cpp
@@ -7,7 +7,7 @@ namespace
 {
 void __noinline testSetValue(BasicConfig& db, int value)
 {
-	BasicConfig::Color::Brightness::Updater bri(db);
+	BasicConfig::Color::Brightness::OuterUpdater bri(db);
 	bri.setRed(value);
 	bri.setGreen(value);
 	bri.setBlue(value);

--- a/samples/Basic_Config/app/properties.cpp
+++ b/samples/Basic_Config/app/properties.cpp
@@ -21,7 +21,7 @@ void printItem(Print& output, const String& tag, unsigned indent, const String& 
 	output << s << value << endl;
 }
 
-void printObject(Print& output, const String& tag, unsigned indent, ConfigDB::Object& obj)
+void printObject(Print& output, const String& tag, unsigned indent, const ConfigDB::Object& obj)
 {
 	printItem(output, tag, indent, toString(obj.typeinfo().type), obj.getName());
 	auto n = obj.getPropertyCount();
@@ -50,7 +50,8 @@ void listProperties(ConfigDB::Database& db, Print& output)
 	output << endl << _F("** Inspect Properties **") << endl;
 
 	output << _F("Database \"") << db.getName() << '"' << endl;
-	for(unsigned i = 0; auto store = db.openStore(i); ++i) {
+	for(unsigned i = 0; i < db.typeinfo.storeCount; ++i) {
+		auto store = db.openStore(i);
 		printObject(output, nullptr, 2, *store);
 	}
 }

--- a/samples/Basic_Config/app/properties.cpp
+++ b/samples/Basic_Config/app/properties.cpp
@@ -50,7 +50,7 @@ void listProperties(ConfigDB::Database& db, Print& output)
 	output << endl << _F("** Inspect Properties **") << endl;
 
 	output << _F("Database \"") << db.getName() << '"' << endl;
-	for(unsigned i = 0; auto store = db.getStore(i); ++i) {
+	for(unsigned i = 0; auto store = db.openStore(i); ++i) {
 		printObject(output, nullptr, 2, *store);
 	}
 }

--- a/samples/Basic_Config/test/color.json
+++ b/samples/Basic_Config/test/color.json
@@ -1,0 +1,1 @@
+{"brightness":{"red":12,"ww":63,"green":44,"blue":8,"cw":63},"colortemp":{"ww":12,"cw":0},"hsv":{"red":0,"magenta":0,"green":0,"blue":0,"yellow":0,"model":0,"cyan":0},"startup_color":"last","outputmode":0}

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -135,10 +135,6 @@ std::shared_ptr<Store> Database::loadStore(const ObjectInfo& storeInfo)
 
 bool Database::save(Store& store) const
 {
-	if(!store.dirty) {
-		return true;
-	}
-
 	debug_d("[CFGDB] Save '%s'", store.getName().c_str());
 
 	auto& reader = getReader(store);
@@ -150,8 +146,6 @@ bool Database::save(Store& store) const
 		readStoreIndex = -1;
 		readStoreRef.reset();
 	}
-
-	store.dirty = !result;
 
 	return result;
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -82,6 +82,8 @@ std::shared_ptr<Store> Database::openStore(unsigned index, bool forWrite)
 	auto& writer = getWriter(*readStoreRef);
 	writer.loadFromFile(*readStoreRef);
 
+	readStoreRef->setReadOnly();
+
 	return readStoreRef;
 }
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Store> Database::openStore(unsigned index, bool forWrite)
 		auto& lock = locks[index];
 		if(lock.weakref.use_count() > 1) {
 			debug_w("[CFGDB] Store '%s' is locked, cannot write", String(storeInfo.name).c_str());
-			return nullptr;
+			return std::make_shared<Store>(*this);
 		}
 
 		lock.weakref = lock.ref = std::make_shared<Store>(*this, storeInfo);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -110,10 +110,8 @@ bool Database::lockStore(std::shared_ptr<Store>& store)
 		return true;
 	}
 
-	// Store is in use, so load a fresh copy
-	// TODO: Instead of re-loading the store, take a copy
-	store.reset();
-	store = loadStore(storeInfo);
+	// Store is in use elsewhere, so take a copy for updating
+	store = std::make_unique<Store>(*store);
 	store->incUpdate();
 	updateRef = store;
 	return true;

--- a/src/DatabaseInfo.cpp
+++ b/src/DatabaseInfo.cpp
@@ -32,4 +32,14 @@ int DatabaseInfo::findStore(const char* name, size_t nameLength) const
 	return -1;
 }
 
+int DatabaseInfo::indexOf(const ObjectInfo& objinfo) const
+{
+	for(unsigned i = 0; i < storeCount; ++i) {
+		if(&objinfo == stores[i]) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 } // namespace ConfigDB

--- a/src/Json/Printer.cpp
+++ b/src/Json/Printer.cpp
@@ -89,7 +89,7 @@ size_t Printer::operator()()
 	// Print child object
 	auto objectCount = object.getObjectCount();
 	if(index < objectCount) {
-		auto obj = const_cast<Object&>(object).getObject(index);
+		auto obj = object.getObject(index);
 		if(object.streamPos++) {
 			n += p->print(',');
 		}
@@ -107,7 +107,7 @@ size_t Printer::operator()()
 
 	// Print property
 	if(index < object.getPropertyCount()) {
-		auto prop = const_cast<Object&>(object).getProperty(index);
+		auto prop = static_cast<const Object&>(object).getProperty(index);
 		if(object.streamPos++) {
 			n += p->print(',');
 		}

--- a/src/Json/Printer.cpp
+++ b/src/Json/Printer.cpp
@@ -58,7 +58,7 @@ size_t Printer::operator()()
 		++indentLength;
 	}
 
-	bool isObject = (object.typeinfo().type <= ObjectType::Object);
+	bool isArray = object.typeinfo().isArray();
 
 	auto quote = [](String s) {
 		::Format::json.escape(s);
@@ -83,7 +83,7 @@ size_t Printer::operator()()
 			n += p->print(quote(*name));
 			n += p->print(colon);
 		}
-		n += p->print(isObject ? '{' : '[');
+		n += p->print(isArray ? '[' : '{');
 	}
 
 	// Print child object
@@ -130,7 +130,7 @@ size_t Printer::operator()()
 			n += newline();
 			n += p->print(indent);
 		}
-		n += p->print(isObject ? '}' : ']');
+		n += p->print(isArray ? ']' : '}');
 	}
 
 	--nesting;

--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -44,7 +44,7 @@ size_t ReadStream::fillStream(Print& p)
 			if(storeIndex == 0) {
 				n += p.print('{');
 			}
-			store = db->getStore(storeIndex);
+			store = db->openStore(storeIndex);
 			auto style = storeIndex == 0 ? Printer::RootStyle::hidden : Printer::RootStyle::normal;
 			printer = Printer(p, *store, format, style);
 		}

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -67,11 +67,6 @@ bool WriteStream::startElement(const JSON::Element& element)
 				// Fatal: store is locked
 				return false;
 			}
-			// Clear the root store first time it's loaded
-			if(!rootSeen) {
-				store->clear();
-				rootSeen = true;
-			}
 			info[0] = *store;
 			info[1] = store->getObject(i);
 			return true;
@@ -94,7 +89,6 @@ bool WriteStream::startElement(const JSON::Element& element)
 			// Fatal: store is locked
 			return false;
 		}
-		store->clear();
 		info[1] = Object(*store);
 		return true;
 	}
@@ -112,6 +106,8 @@ bool WriteStream::startElement(const JSON::Element& element)
 			obj = parent.findObject(element.key, element.keyLength);
 			if(!obj) {
 				debug_w("[JSON] Object '%s' not in schema", element.key);
+			} else if(obj.typeinfo().isArray()) {
+				static_cast<ArrayBase&>(obj).clear();
 			}
 		}
 		info[element.level] = obj;

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -63,6 +63,11 @@ bool WriteStream::startElement(const JSON::Element& element)
 			storeRef.reset();
 			storeRef = db->openStore(root, true);
 			store = storeRef.get();
+			if(!store) {
+				// Fatal: store is locked
+				status = JSON::Status::Cancelled;
+				return false;
+			}
 			// Clear the root store first time it's loaded
 			if(!rootSeen) {
 				store->clear();
@@ -126,7 +131,10 @@ bool WriteStream::startElement(const JSON::Element& element)
 		debug_w("[JSON] Property '%s' not in schema", element.key);
 		return true;
 	}
-	prop.setJsonValue(element.value, element.valueLength);
+	if(!prop.setJsonValue(element.value, element.valueLength)) {
+		status = JSON::Status::Cancelled;
+		return false;
+	}
 	return true;
 }
 

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -63,9 +63,8 @@ bool WriteStream::startElement(const JSON::Element& element)
 			storeRef.reset();
 			storeRef = db->openStore(root, true);
 			store = storeRef.get();
-			if(!store) {
+			if(!store || !*store) {
 				// Fatal: store is locked
-				status = JSON::Status::Cancelled;
 				return false;
 			}
 			// Clear the root store first time it's loaded
@@ -91,9 +90,8 @@ bool WriteStream::startElement(const JSON::Element& element)
 		auto& type = *db->typeinfo.stores[i];
 		storeRef = db->openStore(type, true);
 		store = storeRef.get();
-		if(!store) {
+		if(!store || !*store) {
 			// Fatal: store is locked
-			status = JSON::Status::Cancelled;
 			return false;
 		}
 		store->clear();
@@ -131,11 +129,7 @@ bool WriteStream::startElement(const JSON::Element& element)
 		debug_w("[JSON] Property '%s' not in schema", element.key);
 		return true;
 	}
-	if(!prop.setJsonValue(element.value, element.valueLength)) {
-		status = JSON::Status::Cancelled;
-		return false;
-	}
-	return true;
+	return prop.setJsonValue(element.value, element.valueLength);
 }
 
 size_t WriteStream::write(const uint8_t* data, size_t size)

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -61,7 +61,7 @@ bool WriteStream::startElement(const JSON::Element& element)
 		int i = root.findObject(element.key, element.keyLength);
 		if(i >= 0) {
 			storeRef.reset();
-			storeRef = db->openStore(root);
+			storeRef = db->openStore(root, true);
 			store = storeRef.get();
 			// Clear the root store first time it's loaded
 			if(!rootSeen) {

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -159,6 +159,11 @@ Property Object::findProperty(const char* name, size_t length)
 	return i >= 0 ? getProperty(i) : Property();
 }
 
+void Object::queueUpdate(UpdateCallback callback)
+{
+	return getStore().queueUpdate(callback);
+}
+
 bool Object::commit()
 {
 	return getStore().commit();

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -42,7 +42,8 @@ std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinf
 
 bool Object::lockStore(std::shared_ptr<Store>& store)
 {
-	if(!store->isReadOnly()) {
+	if(store->isLocked()) {
+		store->incUpdate();
 		return true;
 	}
 	if(!store->getDatabase().lockStore(store)) {
@@ -60,7 +61,7 @@ bool Object::lockStore(std::shared_ptr<Store>& store)
 
 void Object::unlockStore(Store& store)
 {
-	--store.updaterCount;
+	store.decUpdate();
 }
 
 Store& Object::getStore()
@@ -74,9 +75,9 @@ Store& Object::getStore()
 	return *store;
 }
 
-bool Object::isReadOnly() const
+bool Object::isLocked() const
 {
-	return getStore().isReadOnly();
+	return getStore().isLocked();
 }
 
 bool Object::writeCheck() const

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -35,9 +35,9 @@ Object& Object::operator=(const Object& other)
 	return *this;
 }
 
-std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinfo)
+std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinfo, bool forWrite)
 {
-	return db.openStore(typeinfo);
+	return db.openStore(typeinfo, forWrite);
 }
 
 Store& Object::getStore()

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -66,6 +66,22 @@ void* Object::getData()
 	}
 }
 
+const void* Object::getData() const
+{
+	if(!parent) {
+		assert(typeinfo().type == ObjectType::Store);
+		return static_cast<const Store*>(this)->getRootData();
+	}
+	switch(parent->typeinfo().type) {
+	case ObjectType::Array:
+	case ObjectType::ObjectArray:
+		return static_cast<const ArrayBase*>(parent)->getItem(dataRef);
+	default:
+		auto data = static_cast<const Object*>(parent)->getData();
+		return static_cast<const uint8_t*>(data) + dataRef;
+	}
+}
+
 unsigned Object::getObjectCount() const
 {
 	if(typeinfo().type == ObjectType::ObjectArray) {

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -223,7 +223,9 @@ Property Object::getProperty(unsigned index)
 		return {};
 	}
 	auto propData = getData<uint8_t>();
-	propData += typeinfo().getPropertyOffset(index);
+	if(propData) {
+		propData += typeinfo().getPropertyOffset(index);
+	}
 	return {getStore(), typeinfo().propinfo[index], propData};
 }
 
@@ -237,7 +239,9 @@ PropertyConst Object::getProperty(unsigned index) const
 		return {};
 	}
 	auto propData = getData<const uint8_t>();
-	propData += typeinfo().getPropertyOffset(index);
+	if(propData) {
+		propData += typeinfo().getPropertyOffset(index);
+	}
 	return {getStore(), typeinfo().propinfo[index], propData};
 }
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -58,6 +58,11 @@ bool Object::lockStore(std::shared_ptr<Store>& store)
 	return true;
 }
 
+void Object::unlockStore(Store& store)
+{
+	--store.updaterCount;
+}
+
 Store& Object::getStore()
 {
 	auto obj = this;

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -94,13 +94,10 @@ void* Object::getDataPtr()
 		assert(typeinfo().type == ObjectType::Store);
 		return static_cast<Store*>(this)->getRootData();
 	}
-	switch(parent->typeinfo().type) {
-	case ObjectType::Array:
-	case ObjectType::ObjectArray:
+	if(parent->typeinfo().isArray()) {
 		return static_cast<ArrayBase*>(parent)->getItem(dataRef);
-	default:
-		return static_cast<uint8_t*>(parent->getDataPtr()) + dataRef;
 	}
+	return static_cast<uint8_t*>(parent->getDataPtr()) + dataRef;
 }
 
 const void* Object::getDataPtr() const
@@ -143,7 +140,7 @@ Object Object::getObject(unsigned index)
 
 Object Object::findObject(const char* name, size_t length)
 {
-	if(typeinfo().type > ObjectType::Object) {
+	if(typeinfo().isArray()) {
 		return {};
 	}
 	int i = typeinfo().findObject(name, length);
@@ -152,7 +149,7 @@ Object Object::findObject(const char* name, size_t length)
 
 Property Object::findProperty(const char* name, size_t length)
 {
-	if(typeinfo().type > ObjectType::Object) {
+	if(typeinfo().isArray()) {
 		return {};
 	}
 	int i = typeinfo().findProperty(name, length);

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -161,8 +161,7 @@ Property Object::findProperty(const char* name, size_t length)
 
 bool Object::commit()
 {
-	auto& store = getStore();
-	return store.getDatabase().save(store);
+	return getStore().commit();
 }
 
 Database& Object::getDatabase()

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -144,9 +144,6 @@ Property Object::findProperty(const char* name, size_t length)
 bool Object::commit()
 {
 	auto& store = getStore();
-	if(store.isReadOnly()) {
-		return false;
-	}
 	return store.getDatabase().save(store);
 }
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -35,14 +35,15 @@ Object& Object::operator=(const Object& other)
 	return *this;
 }
 
-std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinfo, bool forWrite)
+std::shared_ptr<Store> Object::openStore(Database& db, const ObjectInfo& typeinfo, bool lockForWrite)
 {
-	return db.openStore(typeinfo, forWrite);
+	return db.openStore(typeinfo, lockForWrite);
 }
 
-bool Object::unlockStore(std::shared_ptr<Store>& store)
+std::shared_ptr<Store> Object::lockStore(std::shared_ptr<Store> store)
 {
-	return store->getDatabase().unlock(store);
+	store->getDatabase().lockStore(store);
+	return store;
 }
 
 Store& Object::getStore()

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -22,7 +22,7 @@
 
 namespace ConfigDB
 {
-Object::Object(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, &store, store.getObjectDataRef(typeinfo))
+Object::Object(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, store, store.getObjectDataRef(typeinfo))
 {
 }
 
@@ -85,7 +85,7 @@ Object Object::getObject(unsigned index)
 	}
 
 	auto typ = typeinfo().objinfo[index];
-	return Object(*typ, this, typ->getOffset());
+	return Object(*typ, *this, typ->getOffset());
 }
 
 Object Object::findObject(const char* name, size_t length)

--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -126,6 +126,15 @@ void* ArrayData::insert(unsigned index, const void* data)
 	return item;
 }
 
+ArrayPool::ArrayPool(const ArrayPool& other) : PoolData(other)
+{
+	auto src = static_cast<const ArrayData*>(other.buffer);
+	auto dst = static_cast<ArrayData*>(buffer);
+	for(unsigned i = 0; i < count; ++i) {
+		dst[i] = src[i];
+	}
+}
+
 void ArrayPool::clear()
 {
 	auto data = static_cast<ArrayData*>(buffer) + count;

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -25,8 +25,8 @@ namespace ConfigDB
 {
 String PropertyConst::getValue() const
 {
-	assert(info && store && data);
-	if(!store) {
+	assert(info && store);
+	if(!store || !data) {
 		return nullptr;
 	}
 	return store->getValueString(*info, data);

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -52,8 +52,8 @@ bool Property::setJsonValue(const char* value, size_t valueLength)
 	if(!store) {
 		return false;
 	}
-	auto propdata = store->parseString(*info, value, valueLength);
-	memcpy(data, &propdata, info->getSize());
+	auto propdata = const_cast<Store*>(store)->parseString(*info, value, valueLength);
+	memcpy(const_cast<void*>(data), &propdata, info->getSize());
 	return true;
 }
 

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -48,8 +48,8 @@ String PropertyConst::getJsonValue() const
 
 bool Property::setJsonValue(const char* value, size_t valueLength)
 {
-	assert(info && store && data);
-	if(!store) {
+	assert(info && store);
+	if(!store || !data) {
 		return false;
 	}
 	auto propdata = const_cast<Store*>(store)->parseString(*info, value, valueLength);

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -102,11 +102,11 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 
 bool Store::writeCheck() const
 {
-	if(isReadOnly()) {
-		debug_e("[CFGDB] Store is Read-only");
-		return false;
+	if(isLocked()) {
+		return true;
 	}
-	return true;
+	debug_e("[CFGDB] Store is Read-only");
+	return false;
 }
 
 } // namespace ConfigDB

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -18,6 +18,7 @@
  ****/
 
 #include "include/ConfigDB/Database.h"
+#include <debug_progmem.h>
 
 namespace ConfigDB
 {
@@ -96,6 +97,15 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 	}
 
 	return {};
+}
+
+bool Store::writeCheck() const
+{
+	if(readOnly) {
+		debug_e("[CFGDB] Store is Read-only");
+		return false;
+	}
+	return true;
 }
 
 } // namespace ConfigDB

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -109,4 +109,18 @@ bool Store::writeCheck() const
 	return false;
 }
 
+bool Store::commit()
+{
+	if(!dirty) {
+		return true;
+	}
+
+	if(!db.save(*this)) {
+		return false;
+	}
+
+	dirty = false;
+	return true;
+}
+
 } // namespace ConfigDB

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -102,7 +102,7 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 
 bool Store::writeCheck() const
 {
-	if(readOnly) {
+	if(isReadOnly()) {
 		debug_e("[CFGDB] Store is Read-only");
 		return false;
 	}

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -111,6 +111,25 @@ bool Store::writeCheck() const
 	return false;
 }
 
+void Store::queueUpdate(Object::UpdateCallback callback)
+{
+	return db.queueUpdate(*this, callback);
+}
+
+void Store::decUpdate()
+{
+	if(updaterCount == 0) {
+		// No updaters: this happens where earlier call to `Database::lockStore()` failed
+		return;
+	}
+	--updaterCount;
+	CFGDB_DEBUG(" %u", updaterCount)
+	if(updaterCount == 0) {
+		commit();
+		db.checkUpdateQueue(*this);
+	}
+}
+
 bool Store::commit()
 {
 	if(!dirty) {

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -22,6 +22,8 @@
 
 namespace ConfigDB
 {
+uint8_t Store::instanceCount;
+
 void Store::clear()
 {
 	auto& root = typeinfo();

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -28,6 +28,7 @@ void Store::clear()
 	memcpy_P(rootData.get(), root.defaultData, root.structSize);
 	stringPool.clear();
 	arrayPool.clear();
+	dirty = true;
 }
 
 String Store::getFilePath() const

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -82,10 +82,11 @@ public:
 
 /**
  * @brief Used by code generator for integral-typed arrays
- * @tparam ClassType Concrete type provided by code generator
- * @tparam ItemType Type of item
+ * @tparam UpdaterType
+ * @tparam ClassType Contained class with type information
+ * @tparam ItemType
  */
-template <class ClassType, typename ItemType> class ArrayUpdaterTemplate : public Array
+template <class UpdaterType, class ClassType, typename ItemType> class ArrayUpdaterTemplate : public Array
 {
 public:
 	struct ItemRef {
@@ -94,12 +95,12 @@ public:
 
 		operator ItemType() const
 		{
-			return static_cast<ClassType&>(array).getItem(index);
+			return static_cast<UpdaterType&>(array).getItem(index);
 		}
 
-		ItemRef& operator=(const String& value)
+		ItemRef& operator=(const ItemType& value)
 		{
-			static_cast<ClassType&>(array).setItem(index, value);
+			static_cast<UpdaterType&>(array).setItem(index, value);
 			return *this;
 		}
 	};
@@ -152,26 +153,28 @@ public:
 
 /**
  * @brief Used by code generator for String-typed arrays
- * @tparam ClassType Concrete type provided by code generator
- * @tparam ItemType Type of item, not used (always String)
+ * @tparam UpdaterType
+ * @tparam ClassType Contained class with type information
+ * @tparam ItemType always String, but could support string-like objects if we want
  */
-template <class ClassType, typename ItemType> class StringArrayUpdaterTemplate : public ArrayTemplate<ClassType, ItemType>
+template <class UpdaterType, class ClassType, typename ItemType>
+class StringArrayUpdaterTemplate : public ArrayUpdaterTemplate<UpdaterType, ClassType, ItemType>
 {
 public:
-	using ArrayTemplate<ClassType, ItemType>::ArrayTemplate;
+	using ArrayUpdaterTemplate<UpdaterType, ClassType, ItemType>::ArrayUpdaterTemplate;
 
-	void setItem(unsigned index, const String& value)
+	void setItem(unsigned index, const ItemType& value)
 	{
 		*static_cast<StringId*>(ArrayBase::getItem(index)) = this->getStringId(value);
 	}
 
-	void addItem(const String& value)
+	void addItem(const ItemType& value)
 	{
 		auto stringId = this->getStringId(value);
 		this->getArray().add(&stringId);
 	}
 
-	void insertItem(unsigned index, const String& value)
+	void insertItem(unsigned index, const ItemType& value)
 	{
 		auto stringId = this->getStringId(value);
 		this->getArray().insert(index, &stringId);

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -84,7 +84,7 @@ public:
  * @brief Used by code generator for integral-typed arrays
  * @tparam UpdaterType
  * @tparam ClassType Contained class with type information
- * @tparam ItemType
+ * @tparam ItemType Updater item type
  */
 template <class UpdaterType, class ClassType, typename ItemType> class ArrayUpdaterTemplate : public ClassType
 {

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -61,6 +61,33 @@ public:
 template <class ClassType, typename ItemType> class ArrayTemplate : public Array
 {
 public:
+	explicit ArrayTemplate(Store& store) : Array(ClassType::typeinfo, store)
+	{
+	}
+
+	ArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, parent, dataRef)
+	{
+	}
+
+	ItemType getItem(unsigned index) const
+	{
+		return *static_cast<const ItemType*>(getArray()[index]);
+	}
+
+	const ItemType operator[](unsigned index) const
+	{
+		return this->getItem(index);
+	}
+};
+
+/**
+ * @brief Used by code generator for integral-typed arrays
+ * @tparam ClassType Concrete type provided by code generator
+ * @tparam ItemType Type of item
+ */
+template <class ClassType, typename ItemType> class ArrayUpdaterTemplate : public Array
+{
+public:
 	struct ItemRef {
 		Array& array;
 		unsigned index;
@@ -77,17 +104,12 @@ public:
 		}
 	};
 
-	explicit ArrayTemplate(Store& store) : Array(ClassType::typeinfo, store)
+	explicit ArrayUpdaterTemplate(Store& store) : Array(ClassType::typeinfo, store)
 	{
 	}
 
-	ArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, parent, dataRef)
+	ArrayUpdaterTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, parent, dataRef)
 	{
-	}
-
-	ItemType getItem(unsigned index) const
-	{
-		return *static_cast<const ItemType*>(getArray()[index]);
 	}
 
 	void setItem(unsigned index, ItemType value)
@@ -109,11 +131,6 @@ public:
 	{
 		return {*this, index};
 	}
-
-	const ItemType operator[](unsigned index) const
-	{
-		return this->getItem(index);
-	}
 };
 
 /**
@@ -131,6 +148,17 @@ public:
 		auto id = *static_cast<const StringId*>(this->getArray()[index]);
 		return this->getString(id);
 	}
+};
+
+/**
+ * @brief Used by code generator for String-typed arrays
+ * @tparam ClassType Concrete type provided by code generator
+ * @tparam ItemType Type of item, not used (always String)
+ */
+template <class ClassType, typename ItemType> class StringArrayUpdaterTemplate : public ArrayTemplate<ClassType, ItemType>
+{
+public:
+	using ArrayTemplate<ClassType, ItemType>::ArrayTemplate;
 
 	void setItem(unsigned index, const String& value)
 	{

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -86,7 +86,7 @@ public:
  * @tparam ClassType Contained class with type information
  * @tparam ItemType
  */
-template <class UpdaterType, class ClassType, typename ItemType> class ArrayUpdaterTemplate : public Array
+template <class UpdaterType, class ClassType, typename ItemType> class ArrayUpdaterTemplate : public ClassType
 {
 public:
 	struct ItemRef {
@@ -105,13 +105,7 @@ public:
 		}
 	};
 
-	explicit ArrayUpdaterTemplate(Store& store) : Array(ClassType::typeinfo, store)
-	{
-	}
-
-	ArrayUpdaterTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, parent, dataRef)
-	{
-	}
+	using ClassType::ClassType;
 
 	void setItem(unsigned index, ItemType value)
 	{
@@ -120,12 +114,12 @@ public:
 
 	void addItem(ItemType value)
 	{
-		getArray().add(&value);
+		this->getArray().add(&value);
 	}
 
 	void insertItem(unsigned index, ItemType value)
 	{
-		getArray().insert(index, &value);
+		this->getArray().insert(index, &value);
 	}
 
 	ItemRef operator[](unsigned index)

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -76,7 +76,7 @@ public:
 
 	const ItemType operator[](unsigned index) const
 	{
-		return this->getItem(index);
+		return static_cast<const ClassType*>(this)->getItem(index);
 	}
 };
 

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -41,6 +41,11 @@ public:
 		return {getStore(), getItemType(), getArray()[index]};
 	}
 
+	PropertyConst getProperty(unsigned index) const
+	{
+		return {getStore(), getItemType(), getArray()[index]};
+	}
+
 	const PropertyInfo& getItemType() const
 	{
 		assert(typeinfo().propertyCount == 1);

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -76,7 +76,7 @@ public:
 	{
 	}
 
-	ArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, &parent, dataRef)
+	ArrayTemplate(Object& parent, uint16_t dataRef) : Array(ClassType::typeinfo, parent, dataRef)
 	{
 	}
 

--- a/src/include/ConfigDB/ArrayBase.h
+++ b/src/include/ConfigDB/ArrayBase.h
@@ -47,6 +47,11 @@ public:
 		return getArray()[index];
 	}
 
+	const void* getItem(unsigned index) const
+	{
+		return getArray()[index];
+	}
+
 	void addItem(const void* value)
 	{
 		getArray().add(value);

--- a/src/include/ConfigDB/ArrayBase.h
+++ b/src/include/ConfigDB/ArrayBase.h
@@ -57,6 +57,11 @@ public:
 		getArray().add(value);
 	}
 
+	void clear()
+	{
+		getArray().clear();
+	}
+
 protected:
 	ArrayId& getId()
 	{

--- a/src/include/ConfigDB/ArrayBase.h
+++ b/src/include/ConfigDB/ArrayBase.h
@@ -60,12 +60,12 @@ public:
 protected:
 	ArrayId& getId()
 	{
-		return *static_cast<ArrayId*>(getData());
+		return *getData<ArrayId>();
 	}
 
 	ArrayId getId() const
 	{
-		return *static_cast<const ArrayId*>(getData());
+		return *getData<const ArrayId>();
 	}
 
 	ArrayData& getArray();

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -59,7 +59,7 @@ public:
 	 */
 	std::shared_ptr<Store> openStore(const ObjectInfo& typeinfo);
 
-	std::shared_ptr<Store> getStore(unsigned index)
+	std::shared_ptr<Store> openStore(unsigned index)
 	{
 		if(index < typeinfo.storeCount) {
 			return openStore(*typeinfo.stores[index]);

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -58,20 +58,20 @@ public:
 	/**
 	 * @brief Open a store instance, load it and return a shared pointer
 	 */
-	std::shared_ptr<Store> openStore(unsigned index, bool forWrite = false);
+	std::shared_ptr<Store> openStore(unsigned index, bool lockForWrite = false);
 
-	std::shared_ptr<Store> openStore(const ObjectInfo& objinfo, bool forWrite = false)
+	std::shared_ptr<Store> openStore(const ObjectInfo& objinfo, bool lockForWrite = false)
 	{
-		return openStore(typeinfo.indexOf(objinfo), forWrite);
+		return openStore(typeinfo.indexOf(objinfo), lockForWrite);
 	}
 
 	bool save(Store& store) const;
 
 	/**
-	 * @brief Unlock a store for writing
+	 * @brief Lock a store for writing
 	 * @retval bool Fails if called more than once
 	 */
-	bool unlock(std::shared_ptr<Store>& store);
+	bool lockStore(std::shared_ptr<Store>& store);
 
 	virtual Reader& getReader(const Store& store) const;
 	virtual Writer& getWriter(const Store& store) const;

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -24,6 +24,7 @@
 #include "Writer.h"
 #include "DatabaseInfo.h"
 #include <Data/CString.h>
+#include <WVector.h>
 
 namespace ConfigDB
 {
@@ -65,6 +66,9 @@ public:
 		return openStore(typeinfo.indexOf(objinfo), lockForWrite);
 	}
 
+	void queueUpdate(Store& store, Object::UpdateCallback callback);
+	void checkUpdateQueue(Store& store);
+
 	bool save(Store& store) const;
 
 	/**
@@ -81,6 +85,16 @@ public:
 private:
 	using UpdateRef = std::weak_ptr<Store>;
 
+	struct UpdateQueueItem {
+		uint8_t storeIndex;
+		Object::UpdateCallback callback;
+
+		bool operator==(int index) const
+		{
+			return int(storeIndex) == index;
+		}
+	};
+
 	std::shared_ptr<Store> loadStore(const ObjectInfo& storeInfo);
 
 	CString path;
@@ -88,6 +102,7 @@ private:
 	// Hold store open for a brief period to avoid thrashing
 	static std::shared_ptr<Store> readStoreRef;
 	std::unique_ptr<UpdateRef[]> updateRefs;
+	Vector<UpdateQueueItem> updateQueue;
 	static int8_t readStoreIndex;
 	static bool callbackQueued;
 };

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -79,21 +79,7 @@ public:
 	const DatabaseInfo& typeinfo;
 
 private:
-	struct UpdateRef {
-		std::weak_ptr<Store> weakref;
-
-		bool isLocked()
-		{
-			auto store = weakref.lock();
-			return store && store->isLocked();
-		}
-
-		UpdateRef& operator=(std::shared_ptr<Store> ref)
-		{
-			this->weakref = ref;
-			return *this;
-		}
-	};
+	using UpdateRef = std::weak_ptr<Store>;
 
 	std::shared_ptr<Store> loadStore(const ObjectInfo& storeInfo);
 

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -67,6 +67,12 @@ public:
 
 	bool save(Store& store) const;
 
+	/**
+	 * @brief Unlock a store for writing
+	 * @retval bool Fails if called more than once
+	 */
+	bool unlock(std::shared_ptr<Store>& store);
+
 	virtual Reader& getReader(const Store& store) const;
 	virtual Writer& getWriter(const Store& store) const;
 
@@ -76,6 +82,18 @@ private:
 	struct WriterLock {
 		std::shared_ptr<Store> ref;
 		std::weak_ptr<Store> weakref;
+
+		explicit operator bool() const
+		{
+			return weakref.use_count() > 1;
+		}
+
+		WriterLock& operator=(std::shared_ptr<Store> ref)
+		{
+			this->ref = ref;
+			this->weakref = ref;
+			return *this;
+		}
 	};
 
 	CString path;

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -80,7 +80,7 @@ public:
 
 private:
 	struct WriterLock {
-		std::shared_ptr<Store> ref;
+		// std::shared_ptr<Store> ref;
 		std::weak_ptr<Store> weakref;
 
 		explicit operator bool() const
@@ -90,7 +90,7 @@ private:
 
 		WriterLock& operator=(std::shared_ptr<Store> ref)
 		{
-			this->ref = ref;
+			// this->ref = ref;
 			this->weakref = ref;
 			return *this;
 		}

--- a/src/include/ConfigDB/DatabaseInfo.h
+++ b/src/include/ConfigDB/DatabaseInfo.h
@@ -29,6 +29,7 @@ struct DatabaseInfo {
 	const ObjectInfo* stores[];
 
 	int findStore(const char* name, size_t nameLength) const;
+	int indexOf(const ObjectInfo& objinfo) const;
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Json/WriteStream.h
+++ b/src/include/ConfigDB/Json/WriteStream.h
@@ -55,6 +55,8 @@ public:
 		return true;
 	}
 
+	using ReadWriteStream::write;
+
 	size_t write(const uint8_t* data, size_t size) override;
 
 	uint16_t readMemoryBlock(char*, int) override

--- a/src/include/ConfigDB/Json/WriteStream.h
+++ b/src/include/ConfigDB/Json/WriteStream.h
@@ -87,6 +87,11 @@ public:
 		return MimeType::JSON;
 	}
 
+	JSON::Status getStatus() const
+	{
+		return status;
+	}
+
 private:
 	bool startElement(const JSON::Element& element) override;
 

--- a/src/include/ConfigDB/Json/WriteStream.h
+++ b/src/include/ConfigDB/Json/WriteStream.h
@@ -107,7 +107,6 @@ private:
 	JSON::StaticStreamingParser<1024> parser;
 	Object info[JSON::StreamingParser::maxNesting]{};
 	JSON::Status status{};
-	bool rootSeen{}; ///< Set first time root store is seen (and cleared)
 };
 
 } // namespace ConfigDB::Json

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -272,7 +272,7 @@ public:
 	}
 
 	explicit OuterObjectUpdaterTemplate(Database& db)
-		: OuterObjectUpdaterTemplate(this->openStore(db, StoreType::typeinfo))
+		: OuterObjectUpdaterTemplate(this->openStore(db, StoreType::typeinfo, true))
 	{
 	}
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -157,7 +157,7 @@ protected:
 		return !isReadOnly() && getDataPtr();
 	}
 
-	std::shared_ptr<Store> lockStore(std::shared_ptr<Store> store);
+	bool lockStore(std::shared_ptr<Store>& store);
 
 	bool writeCheck() const;
 
@@ -227,7 +227,8 @@ public:
 
 	Updater beginUpdate()
 	{
-		return Updater(this->lockStore(store));
+		this->lockStore(store);
+		return Updater(store);
 	}
 
 private:

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -159,6 +159,8 @@ protected:
 
 	bool lockStore(std::shared_ptr<Store>& store);
 
+	void unlockStore(Store& store);
+
 	bool writeCheck() const;
 
 	void* getDataPtr();
@@ -253,6 +255,7 @@ public:
 	~ObjectUpdaterTemplate()
 	{
 		commit();
+		this->unlockStore(*store);
 	}
 
 	explicit operator bool() const

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -210,6 +210,11 @@ public:
 	ObjectTemplate(Object& parent, uint16_t dataRef) : Object(ClassType::typeinfo, parent, dataRef)
 	{
 	}
+
+	ObjectTemplate(const Object& parent, uint16_t dataRef)
+		: Object(ClassType::typeinfo, const_cast<Object&>(parent), dataRef)
+	{
+	}
 };
 
 /**
@@ -217,8 +222,7 @@ public:
  * @tparam ClassType Concrete type provided by code generator
  * @tparam StoreType Object type for store root
  */
-template <class ContainedClassType, class StoreType>
-class OuterObjectTemplate : public ContainedClassType
+template <class ContainedClassType, class StoreType> class OuterObjectTemplate : public ContainedClassType
 {
 public:
 	OuterObjectTemplate(std::shared_ptr<Store> store) : ContainedClassType(*store), store(store)

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -249,6 +249,11 @@ public:
 	{
 	}
 
+	~ObjectUpdaterTemplate()
+	{
+		commit();
+	}
+
 	explicit operator bool() const
 	{
 		return Object::operator bool() && isWriteable();

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -69,7 +69,7 @@ public:
 	 */
 	bool isStore() const
 	{
-		return typeinfoPtr->type == ObjectType::Store && !parent && typeinfoPtr != &ObjectInfo::empty;
+		return typeinfoPtr->type == ObjectType::Store && !parent;
 	}
 
 	Store& getStore();
@@ -244,9 +244,10 @@ protected:
 
 /**
  * @brief Used by code generator
- * @tparam ClassType Outer class type provided by code generator
+ * @tparam UpdaterType
+ * @tparam ClassType Contained class with type information
  */
-template <class ClassType> class ObjectUpdaterTemplate : public Object
+template <class UpdaterType, class ClassType> class ObjectUpdaterTemplate : public Object
 {
 public:
 	ObjectUpdaterTemplate(Store& store) : Object(ClassType::typeinfo, store)
@@ -265,14 +266,13 @@ public:
 
 /**
  * @brief Used by code generator
- * @tparam ClassType Outer class type provided by code generator
+ * @tparam ContainedClassType
  */
-template <class ContainedClassType, class StoreType> class OuterObjectUpdaterTemplate : public ContainedClassType
+template <class ContainedClassType, class StoreType>
+class OuterObjectUpdaterTemplate : public ContainedClassType::Updater
 {
 public:
-	using Updater = typename ContainedClassType::Updater;
-
-	OuterObjectUpdaterTemplate(std::shared_ptr<Store> store) : ContainedClassType(*store), store(store)
+	OuterObjectUpdaterTemplate(std::shared_ptr<Store> store) : ContainedClassType::Updater(*store), store(store)
 	{
 	}
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -97,6 +97,11 @@ public:
 	 */
 	Object getObject(unsigned index);
 
+	const Object getObject(unsigned index) const
+	{
+		return const_cast<Object*>(this)->getObject(index);
+	}
+
 	/**
 	 * @brief Find child object by name
 	 */

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -142,10 +142,7 @@ public:
 
 	void* getData();
 
-	const void* getData() const
-	{
-		return const_cast<Object*>(this)->getData();
-	}
+	const void* getData() const;
 
 protected:
 	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo, bool forWrite);
@@ -204,7 +201,8 @@ public:
 	{
 	}
 
-	OuterObjectTemplate(Database& db, bool forWrite = false) : OuterObjectTemplate(this->openStore(db, StoreType::typeinfo, forWrite))
+	OuterObjectTemplate(Database& db, bool forWrite = false)
+		: OuterObjectTemplate(this->openStore(db, StoreType::typeinfo, forWrite))
 	{
 	}
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -278,7 +278,6 @@ public:
 
 	~OuterObjectUpdaterTemplate()
 	{
-		this->commit();
 		this->unlockStore(*store);
 	}
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -61,7 +61,7 @@ public:
 
 	explicit operator bool() const
 	{
-		return typeinfoPtr != &ObjectInfo::empty && getData();
+		return typeinfoPtr != &ObjectInfo::empty;
 	}
 
 	/**
@@ -114,10 +114,7 @@ public:
 	 */
 	Property getProperty(unsigned index);
 
-	PropertyConst getProperty(unsigned index) const
-	{
-		return const_cast<Object*>(this)->getProperty(index);
-	}
+	PropertyConst getProperty(unsigned index) const;
 
 	/**
 	 * @brief Find property by name
@@ -140,12 +137,24 @@ public:
 		return *typeinfoPtr;
 	}
 
-	void* getData();
+	template <typename T> T* getData()
+	{
+		return static_cast<T*>(getDataPtr());
+	}
 
-	const void* getData() const;
+	template <typename T> const T* getData() const
+	{
+		return static_cast<const T*>(getDataPtr());
+	}
 
 protected:
 	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo, bool forWrite);
+
+	bool writeCheck() const;
+
+	void* getDataPtr();
+
+	const void* getDataPtr() const;
 
 	String getString(StringId id) const;
 
@@ -176,6 +185,10 @@ public:
 template <class ClassType> class ObjectTemplate : public Object
 {
 public:
+	ObjectTemplate() : Object(ClassType::typeinfo)
+	{
+	}
+
 	ObjectTemplate(Store& store, unsigned index, bool forWrite = false) : Object(store, index, forWrite)
 	{
 	}

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -148,7 +148,7 @@ public:
 	}
 
 protected:
-	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo);
+	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo, bool forWrite);
 
 	String getString(StringId id) const;
 
@@ -179,7 +179,7 @@ public:
 template <class ClassType> class ObjectTemplate : public Object
 {
 public:
-	ObjectTemplate(const ObjectInfo& typeinfo, Store& store) : Object(typeinfo, store)
+	ObjectTemplate(Store& store, unsigned index, bool forWrite = false) : Object(store, index, forWrite)
 	{
 	}
 
@@ -204,7 +204,7 @@ public:
 	{
 	}
 
-	OuterObjectTemplate(Database& db) : OuterObjectTemplate(this->openStore(db, StoreType::typeinfo))
+	OuterObjectTemplate(Database& db, bool forWrite = false) : OuterObjectTemplate(this->openStore(db, StoreType::typeinfo, forWrite))
 	{
 	}
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -61,7 +61,7 @@ public:
 
 	explicit operator bool() const
 	{
-		return typeinfoPtr != &ObjectInfo::empty;
+		return typeinfoPtr != &ObjectInfo::empty && getData();
 	}
 
 	/**

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -150,11 +150,14 @@ public:
 protected:
 	std::shared_ptr<Store> openStore(Database& db, const ObjectInfo& typeinfo, bool lockForWrite = false);
 
-	bool isReadOnly() const;
+	bool isLocked() const;
 
 	bool isWriteable() const
 	{
-		return !isReadOnly() && getDataPtr();
+		if(isLocked()) {
+			assert(getDataPtr());
+		}
+		return isLocked() && getDataPtr();
 	}
 
 	bool lockStore(std::shared_ptr<Store>& store);

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -245,7 +245,8 @@ public:
 
 /**
  * @brief Used by code generator
- * @tparam ContainedClassType
+ * @tparam UpdaterType
+ * @tparam StoreType
  */
 template <class UpdaterType, class StoreType> class OuterObjectUpdaterTemplate : public UpdaterType
 {
@@ -270,8 +271,9 @@ private:
 
 /**
  * @brief Used by code generator
- * @tparam ClassType Concrete type provided by code generator
- * @tparam StoreType Object type for store root
+ * @tparam ContainedClassType
+ * @tparam UpdaterType
+ * @tparam StoreType
  */
 template <class ContainedClassType, class UpdaterType, class StoreType>
 class OuterObjectTemplate : public ContainedClassType

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -54,8 +54,8 @@ public:
 
 	Object(const ObjectInfo& typeinfo, Store& store);
 
-	Object(const ObjectInfo& typeinfo, Object* parent, uint16_t dataRef)
-		: typeinfoPtr(&typeinfo), parent(parent), dataRef(dataRef)
+	Object(const ObjectInfo& typeinfo, Object& parent, uint16_t dataRef)
+		: typeinfoPtr(&typeinfo), parent(&parent), dataRef(dataRef)
 	{
 	}
 
@@ -187,7 +187,7 @@ public:
 	{
 	}
 
-	ObjectTemplate(Object& parent, uint16_t dataRef) : Object(ClassType::typeinfo, &parent, dataRef)
+	ObjectTemplate(Object& parent, uint16_t dataRef) : Object(ClassType::typeinfo, parent, dataRef)
 	{
 	}
 };

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -72,12 +72,29 @@ public:
 	{
 	}
 
-	ItemType operator[](unsigned index)
+	const ItemType operator[](unsigned index) const
 	{
 		return ItemType(*this, index);
 	}
+};
 
-	const ItemType operator[](unsigned index) const
+/**
+ * @brief Used by code generator
+ * @tparam ClassType Concrete class type
+ * @tparam ItemType Array item class type
+ */
+template <class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ObjectArray
+{
+public:
+	explicit ObjectArrayUpdaterTemplate(Store& store) : ObjectArray(ClassType::typeinfo, store)
+	{
+	}
+
+	ObjectArrayUpdaterTemplate(Object& parent, uint16_t dataRef) : ObjectArray(ClassType::typeinfo, parent, dataRef)
+	{
+	}
+
+	ItemType operator[](unsigned index)
 	{
 		return ItemType(*this, index);
 	}

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -84,6 +84,9 @@ public:
 
 	ItemType addItem()
 	{
+		if(!writeCheck()) {
+			return ItemType(*this, 0);
+		}
 		auto& array = getArray();
 		auto index = array.getCount();
 		array.add(ItemType::typeinfo.defaultData);
@@ -92,6 +95,9 @@ public:
 
 	ItemType insertItem(unsigned index)
 	{
+		if(!writeCheck()) {
+			return ItemType(*this, 0);
+		}
 		getArray().insert(index, ItemType::typeinfo.defaultData);
 		return ItemType(*this, index);
 	}

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -82,7 +82,7 @@ public:
  * @brief Used by code generator
  * @tparam UpdaterType
  * @tparam ClassType Contained class with type information
- * @tparam ItemType
+ * @tparam ItemType Updater item type
  */
 template <class UpdaterType, class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ClassType
 {

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -80,10 +80,11 @@ public:
 
 /**
  * @brief Used by code generator
- * @tparam ClassType Concrete class type
- * @tparam ItemType Array item class type
+ * @tparam UpdaterType
+ * @tparam ClassType Contained class with type information
+ * @tparam ItemType
  */
-template <class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ObjectArray
+template <class UpdaterType, class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ObjectArray
 {
 public:
 	using Item = typename ItemType::Updater;

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -33,7 +33,7 @@ public:
 
 	Object getObject(unsigned index)
 	{
-		return Object(getItemType(), this, index);
+		return Object(getItemType(), *this, index);
 	}
 
 	unsigned getObjectCount() const
@@ -47,7 +47,7 @@ public:
 		auto& array = getArray();
 		auto ref = array.getCount();
 		array.add(itemType.defaultData);
-		return Object(itemType, this, ref);
+		return Object(itemType, *this, ref);
 	}
 
 	const ObjectInfo& getItemType() const
@@ -68,7 +68,7 @@ public:
 	{
 	}
 
-	ObjectArrayTemplate(Object& parent, uint16_t dataRef) : ObjectArray(ClassType::typeinfo, &parent, dataRef)
+	ObjectArrayTemplate(Object& parent, uint16_t dataRef) : ObjectArray(ClassType::typeinfo, parent, dataRef)
 	{
 	}
 

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -86,6 +86,8 @@ public:
 template <class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ObjectArray
 {
 public:
+	using Item = typename ItemType::Updater;
+
 	explicit ObjectArrayUpdaterTemplate(Store& store) : ObjectArray(ClassType::typeinfo, store)
 	{
 	}
@@ -94,29 +96,29 @@ public:
 	{
 	}
 
-	ItemType operator[](unsigned index)
+	Item operator[](unsigned index)
 	{
-		return ItemType(*this, index);
+		return Item(*this, index);
 	}
 
-	ItemType addItem()
+	Item addItem()
 	{
 		if(!writeCheck()) {
-			return ItemType(*this, 0);
+			return Item(*this, 0);
 		}
 		auto& array = getArray();
 		auto index = array.getCount();
 		array.add(ItemType::typeinfo.defaultData);
-		return ItemType(*this, index);
+		return Item(*this, index);
 	}
 
-	ItemType insertItem(unsigned index)
+	Item insertItem(unsigned index)
 	{
 		if(!writeCheck()) {
-			return ItemType(*this, 0);
+			return Item(*this, 0);
 		}
-		getArray().insert(index, ItemType::typeinfo.defaultData);
-		return ItemType(*this, index);
+		getArray().insert(index, Item::typeinfo.defaultData);
+		return Item(*this, index);
 	}
 };
 

--- a/src/include/ConfigDB/ObjectArray.h
+++ b/src/include/ConfigDB/ObjectArray.h
@@ -84,42 +84,34 @@ public:
  * @tparam ClassType Contained class with type information
  * @tparam ItemType
  */
-template <class UpdaterType, class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ObjectArray
+template <class UpdaterType, class ClassType, class ItemType> class ObjectArrayUpdaterTemplate : public ClassType
 {
 public:
-	using Item = typename ItemType::Updater;
+	using ClassType::ClassType;
 
-	explicit ObjectArrayUpdaterTemplate(Store& store) : ObjectArray(ClassType::typeinfo, store)
+	ItemType operator[](unsigned index)
 	{
+		return ItemType(*this, index);
 	}
 
-	ObjectArrayUpdaterTemplate(Object& parent, uint16_t dataRef) : ObjectArray(ClassType::typeinfo, parent, dataRef)
+	ItemType addItem()
 	{
-	}
-
-	Item operator[](unsigned index)
-	{
-		return Item(*this, index);
-	}
-
-	Item addItem()
-	{
-		if(!writeCheck()) {
-			return Item(*this, 0);
+		if(!this->writeCheck()) {
+			return ItemType(*this, 0);
 		}
-		auto& array = getArray();
+		auto& array = this->getArray();
 		auto index = array.getCount();
 		array.add(ItemType::typeinfo.defaultData);
-		return Item(*this, index);
+		return ItemType(*this, index);
 	}
 
-	Item insertItem(unsigned index)
+	ItemType insertItem(unsigned index)
 	{
-		if(!writeCheck()) {
+		if(!this->writeCheck()) {
 			return Item(*this, 0);
 		}
-		getArray().insert(index, Item::typeinfo.defaultData);
-		return Item(*this, index);
+		this->getArray().insert(index, ItemType::typeinfo.defaultData);
+		return ItemType(*this, index);
 	}
 };
 

--- a/src/include/ConfigDB/ObjectInfo.h
+++ b/src/include/ConfigDB/ObjectInfo.h
@@ -52,6 +52,11 @@ struct ObjectInfo {
 
 	ObjectInfo(const ObjectInfo&) = delete;
 
+	bool isArray() const
+	{
+		return type == ObjectType::Array || type == ObjectType::ObjectArray;
+	}
+
 	String getTypeDesc() const;
 
 	/**

--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -34,7 +34,28 @@ public:
 		assert(itemSize > 0 && itemSize <= 255);
 	}
 
-	PoolData(const PoolData&) = delete;
+	PoolData(const PoolData& other)
+	{
+		*this = other;
+	}
+
+	PoolData(PoolData&& other)
+	{
+		std::swap(buffer, other.buffer);
+		std::swap(count, other.count);
+		std::swap(space, other.space);
+		itemSize = other.itemSize;
+	}
+
+	PoolData& operator=(const PoolData& other)
+	{
+		buffer = malloc(other.usage());
+		count = other.count;
+		space = other.space;
+		itemSize = other.itemSize;
+		memcpy(buffer, other.buffer, count * itemSize);
+		return *this;
+	}
 
 	size_t getCount() const
 	{
@@ -253,6 +274,8 @@ public:
 	ArrayPool() : PoolData(sizeof(ArrayData))
 	{
 	}
+
+	ArrayPool(const ArrayPool& other);
 
 	~ArrayPool()
 	{

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -54,7 +54,8 @@ public:
 	 * @param info Property information
 	 * @param data Pointer to location where value is stored
 	 */
-	PropertyConst(const Store& store, const PropertyInfo& info, const void* data) : info(&info), store(&store), data(data)
+	PropertyConst(const Store& store, const PropertyInfo& info, const void* data)
+		: info(&info), store(&store), data(data)
 	{
 	}
 

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -54,7 +54,7 @@ public:
 	 * @param info Property information
 	 * @param data Pointer to location where value is stored
 	 */
-	PropertyConst(Store& store, const PropertyInfo& info, void* data) : info(&info), store(&store), data(data)
+	PropertyConst(const Store& store, const PropertyInfo& info, const void* data) : info(&info), store(&store), data(data)
 	{
 	}
 
@@ -74,8 +74,8 @@ public:
 
 protected:
 	const PropertyInfo* info;
-	Store* store{};
-	void* data{};
+	const Store* store{};
+	const void* data{};
 };
 
 class Property : public PropertyConst

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -103,14 +103,6 @@ public:
 		return arrayPool;
 	}
 
-	/**
-	 * @brief When opened for read-only the database calls this to guard against writes
-	 */
-	void setReadOnly()
-	{
-		readOnly = true;
-	}
-
 	bool isReadOnly() const
 	{
 		return readOnly;
@@ -121,6 +113,7 @@ public:
 protected:
 	friend class Object;
 	friend class ArrayBase;
+	friend class Database;
 
 	ArrayPool arrayPool;
 	StringPool stringPool;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -26,7 +26,12 @@
 #include <WString.h>
 #include <memory>
 
+#if DEBUG_VERBOSE_LEVEL == DBG
 #include <debug_progmem.h>
+#define CFGDB_DEBUG(fmt, ...) debug_e("[CFGDB] %s() %s %p" fmt, __FUNCTION__, getName().c_str(), this, ##__VA_ARGS__);
+#else
+#define CFGDB_DEBUG(...)
+#endif
 
 namespace ConfigDB
 {
@@ -50,6 +55,12 @@ public:
 	Store(Database& db, const ObjectInfo& typeinfo)
 		: Object(typeinfo), db(db), rootData(std::make_unique<uint8_t[]>(typeinfo.structSize))
 	{
+		CFGDB_DEBUG("")
+	}
+
+	~Store()
+	{
+		CFGDB_DEBUG("")
 	}
 
 	Store(const Store&) = delete;
@@ -124,13 +135,17 @@ protected:
 	void incUpdate()
 	{
 		++updaterCount;
-		debug_i("[CFGDB] LockStore '%s' %u", getName().c_str(), updaterCount);
+		CFGDB_DEBUG(" %u", updaterCount)
 	}
 
 	void decUpdate()
 	{
+		if(updaterCount == 0) {
+			// No updaters: this happens where earlier call to `Database::lockStore()` failed
+			return;
+		}
 		--updaterCount;
-		debug_i("[CFGDB] UnlockStore '%s' %u", getName().c_str(), updaterCount);
+		CFGDB_DEBUG(" %u", updaterCount)
 	}
 
 	ArrayPool arrayPool;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -76,6 +76,15 @@ public:
 
 	uint8_t* getRootData()
 	{
+		// Check store mode permits writing
+		if(readOnly) {
+			abort();
+		}
+		return rootData.get();
+	}
+
+	const uint8_t* getRootData() const
+	{
 		return rootData.get();
 	}
 
@@ -98,6 +107,19 @@ public:
 		return arrayPool;
 	}
 
+	/**
+	 * @brief When opened for read-only the database calls this to guard against writes
+	 */
+	void setReadOnly()
+	{
+		readOnly = true;
+	}
+
+	bool isReadOnly() const
+	{
+		return readOnly;
+	}
+
 protected:
 	friend class Object;
 	friend class ArrayBase;
@@ -108,6 +130,7 @@ protected:
 private:
 	Database& db;
 	std::unique_ptr<uint8_t[]> rootData;
+	bool readOnly{};
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -161,6 +161,8 @@ protected:
 	friend class ArrayBase;
 	friend class Database;
 
+	void queueUpdate(Object::UpdateCallback callback);
+
 	bool commit();
 
 	void incUpdate()
@@ -169,18 +171,7 @@ protected:
 		CFGDB_DEBUG(" %u", updaterCount)
 	}
 
-	void decUpdate()
-	{
-		if(updaterCount == 0) {
-			// No updaters: this happens where earlier call to `Database::lockStore()` failed
-			return;
-		}
-		--updaterCount;
-		if(updaterCount == 0) {
-			commit();
-		}
-		CFGDB_DEBUG(" %u", updaterCount)
-	}
+	void decUpdate();
 
 	ArrayPool arrayPool;
 	StringPool stringPool;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -36,6 +36,10 @@ class Database;
 class Store : public Object
 {
 public:
+	Store(Database& db) : Object(), db(db)
+	{
+	}
+
 	/**
 	 * @brief Storage instance
 	 * @param db Database which manages this store

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -76,7 +76,11 @@ public:
 
 	uint8_t* getRootData()
 	{
-		return writeCheck() ? rootData.get() : nullptr;
+		if(!writeCheck()) {
+			return nullptr;
+		}
+		dirty = true;
+		return rootData.get();
 	}
 
 	const uint8_t* getRootData() const
@@ -122,6 +126,7 @@ private:
 	Database& db;
 	std::unique_ptr<uint8_t[]> rootData;
 	bool readOnly{};
+	bool dirty{};
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -76,11 +76,7 @@ public:
 
 	uint8_t* getRootData()
 	{
-		// Check store mode permits writing
-		if(readOnly) {
-			abort();
-		}
-		return rootData.get();
+		return writeCheck() ? rootData.get() : nullptr;
 	}
 
 	const uint8_t* getRootData() const
@@ -119,6 +115,8 @@ public:
 	{
 		return readOnly;
 	}
+
+	bool writeCheck() const;
 
 protected:
 	friend class Object;

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -132,6 +132,8 @@ protected:
 	friend class ArrayBase;
 	friend class Database;
 
+	bool commit();
+
 	void incUpdate()
 	{
 		++updaterCount;
@@ -145,6 +147,9 @@ protected:
 			return;
 		}
 		--updaterCount;
+		if(updaterCount == 0) {
+			commit();
+		}
 		CFGDB_DEBUG(" %u", updaterCount)
 	}
 

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -109,7 +109,7 @@ public:
 
 	bool isReadOnly() const
 	{
-		return readOnly;
+		return updaterCount == 0;
 	}
 
 	bool writeCheck() const;
@@ -125,7 +125,7 @@ protected:
 private:
 	Database& db;
 	std::unique_ptr<uint8_t[]> rootData;
-	bool readOnly{};
+	uint8_t updaterCount{};
 	bool dirty{};
 };
 

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -26,6 +26,8 @@
 #include <WString.h>
 #include <memory>
 
+#include <debug_progmem.h>
+
 namespace ConfigDB
 {
 class Database;
@@ -107,9 +109,9 @@ public:
 		return arrayPool;
 	}
 
-	bool isReadOnly() const
+	bool isLocked() const
 	{
-		return updaterCount == 0;
+		return updaterCount != 0;
 	}
 
 	bool writeCheck() const;
@@ -118,6 +120,18 @@ protected:
 	friend class Object;
 	friend class ArrayBase;
 	friend class Database;
+
+	void incUpdate()
+	{
+		++updaterCount;
+		debug_i("[CFGDB] LockStore '%s' %u", getName().c_str(), updaterCount);
+	}
+
+	void decUpdate()
+	{
+		--updaterCount;
+		debug_i("[CFGDB] UnlockStore '%s' %u", getName().c_str(), updaterCount);
+	}
 
 	ArrayPool arrayPool;
 	StringPool stringPool;

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,9 @@
+#####################################################################
+#### Please don't change this file. Use component.mk instead ####
+#####################################################################
+
+ifndef SMING_HOME
+$(error SMING_HOME is not set: please configure it as an environment variable)
+endif
+
+include $(SMING_HOME)/project.mk

--- a/test/README.rst
+++ b/test/README.rst
@@ -1,0 +1,4 @@
+ConfigDB Test
+=============
+
+Application to perform integration tests for ConfigDB library.

--- a/test/app/application.cpp
+++ b/test/app/application.cpp
@@ -1,0 +1,51 @@
+/*
+ * Test framework
+ *
+ * See SmingTest library for details
+ *
+ */
+
+#include <SmingTest.h>
+#include <modules.h>
+
+#define XX(t) extern void REGISTER_TEST(t);
+TEST_MAP(XX)
+#undef XX
+
+static void registerTests()
+{
+#define XX(t)                                                                                                          \
+	REGISTER_TEST(t);                                                                                                  \
+	debug_i("Test '" #t "' registered");
+	TEST_MAP(XX)
+#undef XX
+}
+
+static void testsComplete()
+{
+#if RESTART_DELAY == 0
+	System.restart();
+#else
+	SmingTest::runner.execute(testsComplete, RESTART_DELAY);
+#endif
+}
+
+void init()
+{
+	Serial.setTxBufferSize(1024);
+	Serial.begin(SERIAL_BAUD_RATE);
+	Serial.systemDebugOutput(true);
+
+	debug_e("WELCOME to SMING! Host Tests application running.");
+
+	registerTests();
+
+#ifdef ARCH_HOST
+	fileSetFileSystem(&IFS::Host::getFileSystem());
+#else
+	lfs_mount();
+#endif
+
+	SmingTest::runner.setGroupIntervalMs(TEST_GROUP_INTERVAL);
+	System.onReady([]() { SmingTest::runner.execute(testsComplete); });
+}

--- a/test/app/application.cpp
+++ b/test/app/application.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <SmingTest.h>
+#include <LittleFS.h>
 #include <modules.h>
 
 #define XX(t) extern void REGISTER_TEST(t);

--- a/test/component.mk
+++ b/test/component.mk
@@ -3,8 +3,6 @@ HWCONFIG := test
 COMPONENT_INCDIRS := include
 COMPONENT_SRCDIRS := app modules
 
-COMPONENT_SEARCH_DIRS ?= ../..
-
 # Don't need network
 HOST_NETWORK_OPTIONS := --nonet
 DISABLE_NETWORK := 1

--- a/test/component.mk
+++ b/test/component.mk
@@ -9,7 +9,8 @@ DISABLE_NETWORK := 1
 
 COMPONENT_DEPENDS := \
 	SmingTest \
-	ConfigDB
+	ConfigDB \
+	LittleFS
 
 # Time in milliseconds to pause after a test group has completed
 CONFIG_VARS += TEST_GROUP_INTERVAL

--- a/test/component.mk
+++ b/test/component.mk
@@ -1,0 +1,34 @@
+HWCONFIG := test
+
+COMPONENT_INCDIRS := include
+COMPONENT_SRCDIRS := app modules
+
+COMPONENT_SEARCH_DIRS ?= ../..
+
+# Don't need network
+HOST_NETWORK_OPTIONS := --nonet
+DISABLE_NETWORK := 1
+
+COMPONENT_DEPENDS := \
+	SmingTest \
+	ConfigDB
+
+# Time in milliseconds to pause after a test group has completed
+CONFIG_VARS += TEST_GROUP_INTERVAL
+TEST_GROUP_INTERVAL ?= 500
+APP_CFLAGS += -DTEST_GROUP_INTERVAL=$(TEST_GROUP_INTERVAL)
+
+# Time in milliseconds to wait before re-starting all tests
+# Set to 0 to perform a system restart after all tests have completed
+CONFIG_VARS += RESTART_DELAY
+ifndef RESTART_DELAY
+ifeq ($(SMING_ARCH),Host)
+RESTART_DELAY = 0
+else
+RESTART_DELAY ?= 10000
+endif
+endif
+APP_CFLAGS += -DRESTART_DELAY=$(RESTART_DELAY)
+
+.PHONY: execute
+execute: flash run

--- a/test/include/modules.h
+++ b/test/include/modules.h
@@ -1,0 +1,3 @@
+// List of test modules to register
+
+#define TEST_MAP(XX) XX(Sharing)

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -91,6 +91,7 @@ public:
 			TEST_ASSERT(false);
 		}
 		// Updater commits changes, read cache evicted
+		REQUIRE_EQ(root.getSimpleBool(), true); // Stale
 
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 1); // root/root2 (updated), no read cache
 
@@ -153,6 +154,7 @@ public:
 		auto asyncUpdated = TestConfig::Root(database).update([this](TestConfig::RootUpdater upd) {
 			Serial << "ASYNC UPDATE" << endl;
 			upd.setSimpleBool(true);
+			Serial << upd << endl;
 			// Must queue this as `complete()` destroys this class immediately
 			System.queueCallback([this]() { complete(); });
 		});

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -84,7 +84,7 @@ public:
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 2); // No change
 
 		// Now try direct
-		if(auto updater = TestConfig::Root::Updater(database)) {
+		if(auto updater = TestConfig::Root::OuterUpdater(database)) {
 			CHECK_EQ(ConfigDB::Store::getInstanceCount(), 2); // No change
 			updater.setSimpleBool(false);
 		} else {
@@ -146,11 +146,11 @@ public:
 		REQUIRE(root5);
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 1);
 
-		auto update = TestConfig::Root::Updater(database);
+		auto update = TestConfig::Root::OuterUpdater(database);
 		REQUIRE(!update);
 
 		// Async update. Can use `auto upd` but no code completion (at least in vscode)
-		auto asyncUpdated = TestConfig::Root(database).update([this](TestConfig::ContainedRoot::Updater upd) {
+		auto asyncUpdated = TestConfig::Root(database).update([this](TestConfig::RootUpdater upd) {
 			Serial << "ASYNC UPDATE" << endl;
 			upd.setSimpleBool(true);
 			// Must queue this as `complete()` destroys this class immediately

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -102,6 +102,8 @@ public:
 		if(auto update = root.beginUpdate()) {
 			update.intArray.addItem(12);
 			REQUIRE_EQ(root.intArray[0], 12);
+			update.intArray[0] = 123;
+			REQUIRE_EQ(root.intArray[0], 123);
 			Serial << root.intArray << endl;
 		}
 
@@ -112,6 +114,9 @@ public:
 		if(auto update = root.beginUpdate()) {
 			update.stringArray.addItem(myString);
 			REQUIRE_EQ(root.stringArray[0], myString);
+			update.stringArray[0] = nullptr;
+			REQUIRE_EQ(root.stringArray[0], nullptr);
+			update.stringArray[0] = myString;
 			Serial << root.stringArray << endl;
 		}
 

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -30,16 +30,16 @@ public:
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 1); // root, root2 share the same store
 
 		// Change value
-		if(auto updater = root.beginUpdate()) {
+		if(auto updater = root.update()) {
 			CHECK_EQ(ConfigDB::Store::getInstanceCount(), 2); // root store is now writeable copy, root2 store unchanged
 			updater.setSimpleBool(true);
 			REQUIRE_EQ(root.getSimpleBool(), true);
 			REQUIRE(updater.commit());
 
 			// Nested updates OK
-			REQUIRE(root.beginUpdate());
-			REQUIRE(root.beginUpdate());
-			REQUIRE(root.beginUpdate());
+			REQUIRE(root.update());
+			REQUIRE(root.update());
+			REQUIRE(root.update());
 
 			REQUIRE_EQ(root2.getSimpleBool(), false); // original value
 
@@ -49,8 +49,8 @@ public:
 			REQUIRE_EQ(root3.getSimpleBool(), true);		  // updated value
 
 			// A second writer must fail
-			REQUIRE(!root2.beginUpdate());
-			REQUIRE(!root3.beginUpdate());
+			REQUIRE(!root2.update());
+			REQUIRE(!root3.update());
 			CHECK_EQ(ConfigDB::Store::getInstanceCount(), 3); // No change
 		} else {
 			TEST_ASSERT(false);
@@ -75,7 +75,7 @@ public:
 			The database doesn't keep track of the referring objects so cannot update them.
 			Here, we're explicitly passing `root2` so that's fine, it's what we've asked for.
 		*/
-		REQUIRE(root2.beginUpdate());
+		REQUIRE(root2.update());
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 2); // root/root2 (updated), read cached
 		REQUIRE_EQ(root2.getSimpleBool(), true);		  // root2 now up to date
 
@@ -99,7 +99,7 @@ public:
 
 		/* Array */
 
-		if(auto update = root.beginUpdate()) {
+		if(auto update = root.update()) {
 			update.intArray.addItem(12);
 			REQUIRE_EQ(root.intArray[0], 12);
 			update.intArray[0] = 123;
@@ -111,7 +111,7 @@ public:
 
 		DEFINE_FSTR_LOCAL(myString, "My String");
 
-		if(auto update = root.beginUpdate()) {
+		if(auto update = root.update()) {
 			update.stringArray.addItem(myString);
 			REQUIRE_EQ(root.stringArray[0], myString);
 			update.stringArray[0] = nullptr;
@@ -122,7 +122,7 @@ public:
 
 		/* Object Array */
 
-		if(auto update = root.beginUpdate()) {
+		if(auto update = root.update()) {
 			auto item = update.objectArray.addItem();
 			item.setIntval1(12);
 			REQUIRE_EQ(root.objectArray[0].getIntval1(), 12);
@@ -132,9 +132,9 @@ public:
 		}
 
 		auto root3 = root;
-		auto root4 = root.beginUpdate();
+		auto root4 = root.update();
 		REQUIRE(root4);
-		auto root5 = root.beginUpdate();
+		auto root5 = root.update();
 		REQUIRE(root5);
 
 		auto update = TestConfig::Root::Updater(database);

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -54,7 +54,6 @@ public:
 		// Now try direct
 		if(auto updater = TestConfig::Root::Updater(database)) {
 			updater.setSimpleBool(false);
-			updater.commit();
 		} else {
 			TEST_ASSERT(false);
 		}

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -67,6 +67,27 @@ public:
 
 		// Verify value has changed
 		REQUIRE_EQ(TestConfig::Root(database).getSimpleBool(), false);
+
+		/* Array */
+
+		if(auto update = root.beginUpdate()) {
+			update.intArray.addItem(12);
+			REQUIRE_EQ(root.intArray[0], 12);
+			update.intArray.removeItem(0);
+			REQUIRE_EQ(root.intArray.getItemCount(), 0);
+			Serial << root.intArray << endl;
+		}
+
+		/* String Array */
+
+		if(auto update = root.beginUpdate()) {
+			DEFINE_FSTR_LOCAL(myString, "My String");
+			update.stringArray.addItem(myString);
+			REQUIRE_EQ(root.stringArray[0], myString);
+			update.stringArray.removeItem(0);
+			REQUIRE_EQ(root.stringArray.getItemCount(), 0);
+			Serial << root.stringArray << endl;
+		}
 	}
 
 private:

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -80,13 +80,27 @@ public:
 
 		/* String Array */
 
+		DEFINE_FSTR_LOCAL(myString, "My String");
+
 		if(auto update = root.beginUpdate()) {
-			DEFINE_FSTR_LOCAL(myString, "My String");
 			update.stringArray.addItem(myString);
 			REQUIRE_EQ(root.stringArray[0], myString);
 			update.stringArray.removeItem(0);
 			REQUIRE_EQ(root.stringArray.getItemCount(), 0);
 			Serial << root.stringArray << endl;
+		}
+
+		/* Object Array */
+
+		if(auto update = root.beginUpdate()) {
+			auto item = update.objectArray.addItem();
+			item.setIntval1(12);
+			REQUIRE_EQ(root.objectArray[0].getIntval1(), 12);
+			item.setStringval2(myString);
+			REQUIRE_EQ(root.objectArray[0].getStringval2(), myString);
+			update.objectArray.removeItem(0);
+			REQUIRE_EQ(root.objectArray.getItemCount(), 0);
+			Serial << root.objectArray << endl;
 		}
 	}
 

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -1,0 +1,50 @@
+/*
+ * Standard.cpp
+ */
+
+#include <SmingTest.h>
+#include <test-config.h>
+#include <Services/Profiling/MinMaxTimes.h>
+
+class SharingTest : public TestGroup
+{
+public:
+	SharingTest() : TestGroup(_F("Standard")), database("test-config")
+	{
+		createDirectory(database.getPath());
+		auto store = database.openStore(0, true);
+		store->clear();
+		database.save(*store);
+	}
+
+	void execute() override
+	{
+		// Verify initial value
+		TestConfig::Root readRoot(database);
+		REQUIRE_EQ(readRoot.getSimpleBool(), false);
+
+		// Change value
+		TestConfig::Root writeRoot(database, true);
+		writeRoot.setSimpleBool(true);
+		REQUIRE_EQ(writeRoot.getSimpleBool(), true);
+		REQUIRE_EQ(readRoot.getSimpleBool(), false); // Not yet changed
+		REQUIRE(writeRoot.commit());
+		REQUIRE_EQ(readRoot.getSimpleBool(), false); // Data is stale
+
+		// A new reader must contain the updated data
+		TestConfig::Root readRoot2(database);
+		REQUIRE_EQ(readRoot2.getSimpleBool(), true);
+
+		// A second writer should fail
+		TestConfig::Root writeRoot2(database, true);
+		REQUIRE(!writeRoot2);
+	}
+
+private:
+	TestConfig database;
+};
+
+void REGISTER_TEST(Sharing)
+{
+	registerGroup<SharingTest>();
+}

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -44,11 +44,6 @@ public:
 			TEST_ASSERT(false);
 		}
 
-		// Updater is out of scope but we converted the store of root so that is still writeable
-		// We need to lock it again
-		// So we need a lock count reference for it.
-
-
 		// Verify store has been unlocked
 		REQUIRE(root.beginUpdate());
 

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -20,24 +20,24 @@ public:
 	void execute() override
 	{
 		// Verify initial value
-		TestConfig::Root readRoot(database);
-		REQUIRE_EQ(readRoot.getSimpleBool(), false);
+		TestConfig::Root root(database);
+		REQUIRE_EQ(root.getSimpleBool(), false);
 
 		// Change value
-		TestConfig::Root writeRoot(database, true);
-		writeRoot.setSimpleBool(true);
-		REQUIRE_EQ(writeRoot.getSimpleBool(), true);
-		REQUIRE_EQ(readRoot.getSimpleBool(), false); // Not yet changed
-		REQUIRE(writeRoot.commit());
-		REQUIRE_EQ(readRoot.getSimpleBool(), false); // Data is stale
+		if(auto updater = root.beginUpdate()) {
+			updater.setSimpleBool(true);
+			// REQUIRE_EQ(root.getSimpleBool(), true);
+			REQUIRE(updater.commit());
 
-		// A new reader must contain the updated data
-		TestConfig::Root readRoot2(database);
-		REQUIRE_EQ(readRoot2.getSimpleBool(), true);
+			// A new reader must contain the updated data
+			TestConfig::Root root2(database);
+			REQUIRE_EQ(root2.getSimpleBool(), true);
 
-		// A second writer should fail
-		TestConfig::Root writeRoot2(database, true);
-		REQUIRE(!writeRoot2);
+			// A second writer must fail
+			REQUIRE(!root2.beginUpdate());
+		} else {
+			TEST_ASSERT(false);
+		}
 	}
 
 private:

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -33,6 +33,8 @@ public:
 
 			// Nested updates OK
 			REQUIRE(root.beginUpdate());
+			REQUIRE(root.beginUpdate());
+			REQUIRE(root.beginUpdate());
 
 			// A new reader must contain the updated data
 			TestConfig::Root root2(database);

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -4,6 +4,18 @@
   "properties": {
     "simple-bool": {
       "type": "boolean"
+    },
+    "int array": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "string array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "simple-bool": {
+      "type": "boolean"
+    }
+  }
+}

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -16,6 +16,21 @@
       "items": {
         "type": "string"
       }
+    },
+    "object array": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "intval1": {
+            "type": "integer"
+          },
+          "stringval2": {
+            "type": "string"
+          }
+        }
+      }
     }
+
   }
 }

--- a/test/test.hw
+++ b/test/test.hw
@@ -1,0 +1,15 @@
+{
+	"name": "Test",
+	"base_config": "standard",
+	"options": [
+		"2m"
+	],
+	"partitions": {
+		"lfs0": {
+			"address": "0x00100000",
+			"size": "400K",
+			"type": "data",
+			"subtype": "littlefs"
+		}
+	}
+}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -458,7 +458,7 @@ def generate_database(db: Database) -> CodeLines:
             [
                 'using OuterObjectTemplate::OuterObjectTemplate;',
                 '',
-                f'class Updater: public ConfigDB::OuterObjectUpdaterTemplate<{obj.typename_contained}::Updater, {obj.store.typename_contained}>',
+                f'class Updater: public ConfigDB::OuterObjectUpdaterTemplate<{obj.typename_contained}, {obj.store.typename_contained}>',
                 '{',
                 ['using OuterObjectUpdaterTemplate::OuterObjectUpdaterTemplate;'],
                 '};',
@@ -498,6 +498,8 @@ def declare_templated_class(obj: Object, tparams: list = None, is_updater: bool 
     template = 'Updater' if is_updater else ''
     update_type = '::Updater' if is_updater else ''
     params = [f'{obj.typename_contained}']
+    if is_updater:
+        params.insert(0, 'Updater')
     if tparams:
         params += tparams
     return [

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -595,7 +595,7 @@ def generate_object(obj: Object) -> CodeLines:
 
     typeinfo = generate_typeinfo(obj)
     constructors = generate_contained_constructors(obj)
-    writer = generate_writer(obj),
+    updater = generate_updater(obj),
 
     if isinstance(obj, ObjectArray):
         item_lines = generate_object(obj.items)
@@ -604,6 +604,7 @@ def generate_object(obj: Object) -> CodeLines:
                 *item_lines.header,
                 *declare_templated_class(obj, [obj.items.typename]),
                 typeinfo.header,
+                updater,
                 constructors,
                 '};',
             ],
@@ -614,6 +615,7 @@ def generate_object(obj: Object) -> CodeLines:
             [
                 *declare_templated_class(obj, [obj.items.ctype]),
                 typeinfo.header,
+                updater,
                 constructors,
                 '};',
             ],
@@ -632,7 +634,7 @@ def generate_object(obj: Object) -> CodeLines:
 
     lines.append(generate_object_struct(obj))
     lines.header += [
-        *writer,
+        *updater,
         constructors,
         *generate_property_accessors(obj)
     ]
@@ -650,60 +652,20 @@ def generate_object(obj: Object) -> CodeLines:
     return lines
 
 
-def generate_writer(obj: Object) -> list:
+def generate_updater(obj: Object) -> list:
     '''Generate code for Object Updater implementation'''
 
-    # constructors = generate_contained_constructors(obj)
-
-    # if isinstance(obj, ObjectArray):
-    #     item_lines = generate_object(obj.items)
-    #     return CodeLines(
-    #         [
-    #             *item_lines.header,
-    #             *declare_templated_class(obj, [obj.items.typename]),
-    #             typeinfo.header,
-    #             writer,
-    #             constructors,
-    #             '};',
-    #         ],
-    #         item_lines.source + typeinfo.source)
-
-    # if isinstance(obj, Array):
-    #     return CodeLines(
-    #         [
-    #             *declare_templated_class(obj, [obj.items.ctype]),
-    #             typeinfo.header,
-    #             constructors,
-    #             '};',
-    #         ],
-    #         typeinfo.source)
-
-    # header = declare_templated_class(obj)
-    header = [
+    return [
         '',
         f'class Updater: public ConfigDB::{obj.base_class}UpdaterTemplate<{obj.typename_contained}, {obj.store.typename_contained}>',
         '{',
         'public:',
-        [f'using ObjectUpdaterTemplate::ObjectUpdaterTemplate;']
+        [f'using {obj.base_class}UpdaterTemplate::{obj.base_class}UpdaterTemplate;'],
+        *generate_property_write_accessors(obj),
+        '',
+        [f'{child.typename_contained}::Updater {child.id};' for child in obj.children],
+        '};'
     ]
-
-    # Append child object definitions
-    for child in obj.children:
-        header += generate_writer(child)
-
-    # header += [constructors]
-    header += generate_property_write_accessors(obj)
-
-    # Contained children member variables
-    if obj.children:
-        header += [
-            '',
-            [f'{child.typename_contained} {child.id};' for child in obj.children],
-        ]
-
-    header += ['};']
-
-    return header
 
 
 def generate_contained_constructors(obj: Object) -> list:

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -457,19 +457,6 @@ def generate_database(db: Database) -> CodeLines:
             'public:',
             [
                 'using OuterObjectTemplate::OuterObjectTemplate;',
-                '',
-                f'class Updater: public ConfigDB::OuterObjectUpdaterTemplate<{obj.typename_contained}, {obj.store.typename_contained}>',
-                '{',
-                ['using OuterObjectUpdaterTemplate::OuterObjectUpdaterTemplate;'],
-                '};',
-                '',
-                'Updater update()',
-                '{',
-                [
-                    'this->lockStore(store);',
-                    'return Updater(store);',
-                ],
-                '}',
             ],
             *[generate_outer_class(child) for child in obj.children if not obj.is_item],
             '};'

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -702,13 +702,15 @@ def generate_updater(obj: Object) -> list:
 
 
 def generate_contained_constructors(obj: Object, is_updater = False) -> list:
-    typename = 'Updater' if is_updater else obj.typename_contained
+    typename = 'Updater' if is_updater else obj.typename
+    typename_contained = 'Updater' if is_updater else obj.typename_contained
     template = 'Updater' if is_updater else ''
     update_type = '::Updater' if is_updater else ''
+    const = '' if is_updater else 'const '
     if obj.is_item:
         return [
             '',
-            f'{obj.typename}(ConfigDB::{obj.parent.base_class}& {obj.parent.id}, uint16_t dataRef):',
+            f'{typename}({const}ConfigDB::{obj.parent.base_class}& {obj.parent.id}, uint16_t dataRef):',
             [', '.join([
                 f'{obj.classname}{template}Template({obj.parent.id}, dataRef)',
                 *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
@@ -721,7 +723,7 @@ def generate_contained_constructors(obj: Object, is_updater = False) -> list:
     if not obj.is_item_member:
         headers = [
             '',
-            f'{typename}(ConfigDB::Store& store): ' + ', '.join([
+            f'{typename_contained}(ConfigDB::Store& store): ' + ', '.join([
                 f'{obj.base_class}{template}Template(store)',
                 *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
             ]),
@@ -732,7 +734,7 @@ def generate_contained_constructors(obj: Object, is_updater = False) -> list:
     if not obj.is_root:
         headers += [
             '',
-            f'{typename}({obj.parent.typename_contained}{update_type}& parent, uint16_t dataRef): ' + ', '.join([
+            f'{typename_contained}({obj.parent.typename_contained}{update_type}& parent, uint16_t dataRef): ' + ', '.join([
                 f'{obj.base_class}{template}Template(parent, dataRef)',
                 *(f'{child.id}(*this, offsetof(Struct, {child.id}))' for child in obj.children)
             ]),

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -550,6 +550,7 @@ def generate_object_struct(obj: Object) -> CodeLines:
         'struct __attribute__((packed)) Struct {',
         [
             'using Ptr = Struct*;',
+            'using ConstPtr = const Struct*;',
             '',
             *(f'{child.typename_struct} {child.id}{{}};' for child in obj.children),
             *(f'{prop.ctype_struct} {prop.id}{{{prop.default_structval}}};' for prop in obj.properties)
@@ -571,7 +572,7 @@ def generate_property_accessors(obj: Object) -> list:
         '',
         f'{prop.ctype_ret} get{prop.typename}() const',
         '{',
-        ['return ' + ('getString(' if prop.ptype == 'string' else f'{prop.ctype_ret}(') + f'Struct::Ptr(getData())->{prop.id});'],
+        ['return ' + ('getString(' if prop.ptype == 'string' else f'{prop.ctype_ret}(') + f'Struct::ConstPtr(getData())->{prop.id});'],
         '}',
         '',
         f'void set{prop.typename}({prop.ctype_constref} value)',

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -681,7 +681,7 @@ def generate_writer(obj: Object) -> list:
     # header = declare_templated_class(obj)
     header = [
         '',
-        f'class Updater: public ConfigDB::{obj.base_class}UpdaterTemplate<{obj.typename_contained}>',
+        f'class Updater: public ConfigDB::{obj.base_class}UpdaterTemplate<{obj.typename_contained}, {obj.store.typename_contained}>',
         '{',
         'public:',
         [f'using ObjectUpdaterTemplate::ObjectUpdaterTemplate;']

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -463,7 +463,7 @@ def generate_database(db: Database) -> CodeLines:
                 ['using OuterObjectUpdaterTemplate::OuterObjectUpdaterTemplate;'],
                 '};',
                 '',
-                'Updater beginUpdate()',
+                'Updater update()',
                 '{',
                 [
                     'this->lockStore(store);',


### PR DESCRIPTION
This PR implements store locking as discussed in #12. Also started a test application with a Sharing module.

Objects are now read-only and have separate `Updater` types to handle writing.

TODO:

* [x] Gracefully fail 'set' and 'commit' operations if store isn't opened for write access.
* [x] Remove set/commit from generated objects and provide separate `Updater` classes.
* [x] Block or `delete` inherited methods which allow write access
* [x] Implement asynchronous updates for classes
* [x] Implement asynchronous updates for streamers. For now, report any failures back to web client so it can retry.
* [x] Tidy sample code
* [ ] Review comments and documentation