### PR TITLE
Add property value range checks

### DIFF
--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -208,8 +208,8 @@ String Object::getString(const PropertyInfo& prop, StringId id) const
 		return String(getStore().stringPool[id]);
 	}
 	if(prop.type == PropertyType::String) {
-		assert(prop.minimum.string);
-		return *prop.minimum.string;
+		assert(prop.defaultString);
+		return *prop.defaultString;
 	}
 	return nullptr;
 }

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -219,6 +219,27 @@ StringId Object::getStringId(const char* value, uint16_t valueLength)
 	return value ? getStore().stringPool.findOrAdd({value, valueLength}) : 0;
 }
 
+void Object::setPropertyValue(const PropertyInfo& prop, uint16_t offset, const void* value)
+{
+	auto data = getData<uint8_t>();
+	if(!data) {
+		return;
+	}
+	data += offset;
+	memcpy(data, value, prop.getSize());
+}
+
+void Object::setPropertyValue(const PropertyInfo& prop, uint16_t offset, const String& value)
+{
+	auto data = getData<uint8_t>();
+	if(!data) {
+		return;
+	}
+	auto id = getStringId(value);
+	data += offset;
+	memcpy(data, &id, sizeof(id));
+}
+
 unsigned Object::getPropertyCount() const
 {
 	if(typeIs(ObjectType::Array)) {

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -226,11 +226,14 @@ void Object::setPropertyValue(const PropertyInfo& prop, uint16_t offset, const v
 		return;
 	}
 	data += offset;
-	memcpy(data, value, prop.getSize());
+	auto& dst = *reinterpret_cast<PropertyData*>(data);
+	auto src = static_cast<const PropertyData*>(value);
+	dst.setValue(prop, src);
 }
 
 void Object::setPropertyValue(const PropertyInfo& prop, uint16_t offset, const String& value)
 {
+	assert(prop.type == PropertyType::String);
 	auto data = getData<uint8_t>();
 	if(!data) {
 		return;

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -207,7 +207,11 @@ String Object::getString(const PropertyInfo& prop, StringId id) const
 	if(id) {
 		return String(getStore().stringPool[id]);
 	}
-	return prop.defaultValue;
+	if(prop.type == PropertyType::String) {
+		assert(prop.defaultValue.string);
+		return *prop.defaultValue.string;
+	}
+	return nullptr;
 }
 
 StringId Object::getStringId(const char* value, uint16_t valueLength)

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -20,6 +20,16 @@
 #include "include/ConfigDB/Property.h"
 #include "include/ConfigDB/Store.h"
 #include <Data/Format/Json.h>
+#include <Data/Range.h>
+
+namespace
+{
+template <typename T> T getPtrValue(const T* value)
+{
+	return value ? *value : 0;
+}
+
+} // namespace
 
 namespace ConfigDB
 {
@@ -55,6 +65,40 @@ bool Property::setJsonValue(const char* value, size_t valueLength)
 	auto propdata = const_cast<Store*>(store)->parseString(*info, value, valueLength);
 	memcpy(const_cast<void*>(data), &propdata, info->getSize());
 	return true;
+}
+
+void PropertyData::setValue(const PropertyInfo& prop, const PropertyData* src)
+{
+	switch(prop.type) {
+	case PropertyType::Boolean:
+		b = src ? src->b : (prop.defaultValue.Int32 != 0);
+		break;
+	case PropertyType::Int8:
+		int8 = src ? TRange(prop.minimum.Int32, prop.maximum.Int32).clip(src->int8) : prop.defaultValue.Int32;
+		break;
+	case PropertyType::Int16:
+		int16 = src ? TRange(prop.minimum.Int32, prop.maximum.Int32).clip(src->int16) : prop.defaultValue.Int32;
+		break;
+	case PropertyType::Int32:
+		int32 = src ? TRange(prop.minimum.Int32, prop.maximum.Int32).clip(src->int32) : prop.defaultValue.Int32;
+		break;
+	case PropertyType::Int64:
+		int64 = src ? src->int64 : getPtrValue(prop.defaultValue.Int64);
+	case PropertyType::UInt8:
+		uint8 = src ? TRange(prop.minimum.UInt32, prop.maximum.UInt32).clip(src->uint8) : prop.defaultValue.UInt32;
+		break;
+	case PropertyType::UInt16:
+		uint16 = src ? TRange(prop.minimum.UInt32, prop.maximum.UInt32).clip(src->uint16) : prop.defaultValue.UInt32;
+		break;
+	case PropertyType::UInt32:
+		uint32 = src ? TRange(prop.minimum.UInt32, prop.maximum.UInt32).clip(src->uint32) : prop.defaultValue.UInt32;
+		break;
+	case PropertyType::UInt64:
+		uint64 = src ? src->uint64 : getPtrValue(prop.defaultValue.UInt64);
+	case PropertyType::String:
+		assert(false);
+		break;
+	}
 }
 
 } // namespace ConfigDB

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -93,7 +93,12 @@ void PropertyData::setValue(const PropertyInfo& prop, const PropertyData& src)
 		int32 = clipInt32(src.int32);
 		break;
 	case PropertyType::Int64:
-		int64 = src.int64;
+		if(prop.minimum.Int64 || prop.maximum.Int64) {
+			int64 = TRange(getPtrValue(prop.minimum.Int64), getPtrValue(prop.maximum.Int64)).clip(src.int64);
+		} else {
+			int64 = src.int64;
+		}
+		break;
 	case PropertyType::UInt8:
 		uint8 = clipUInt32(src.uint8);
 		break;
@@ -104,7 +109,12 @@ void PropertyData::setValue(const PropertyInfo& prop, const PropertyData& src)
 		uint32 = clipUInt32(src.uint32);
 		break;
 	case PropertyType::UInt64:
-		uint64 = src.uint64;
+		if(prop.minimum.UInt64 || prop.maximum.UInt64) {
+			uint64 = TRange(getPtrValue(prop.minimum.UInt64), getPtrValue(prop.maximum.UInt64)).clip(src.uint64);
+		} else {
+			uint64 = src.uint64;
+		}
+		break;
 	case PropertyType::String:
 		assert(false);
 		string = src.string;

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -20,7 +20,6 @@
 #include "include/ConfigDB/Property.h"
 #include "include/ConfigDB/Store.h"
 #include <Data/Format/Json.h>
-#include <Data/Range.h>
 
 namespace
 {
@@ -76,44 +75,33 @@ bool Property::setJsonValue(const char* value, size_t valueLength)
 
 void PropertyData::setValue(const PropertyInfo& prop, const PropertyData& src)
 {
-	auto clipInt32 = [&prop](int32_t value) { return TRange(prop.minimum.Int32, prop.maximum.Int32).clip(value); };
-	auto clipUInt32 = [&prop](uint32_t value) { return TRange(prop.minimum.UInt32, prop.maximum.UInt32).clip(value); };
-
 	switch(prop.type) {
 	case PropertyType::Boolean:
-		b = src.b;
+		boolean = src.boolean;
 		break;
 	case PropertyType::Int8:
-		int8 = clipInt32(src.int8);
+		int8 = prop.int32.clip(src.int8);
 		break;
 	case PropertyType::Int16:
-		int16 = clipInt32(src.int16);
+		int16 = prop.int32.clip(src.int16);
 		break;
 	case PropertyType::Int32:
-		int32 = clipInt32(src.int32);
+		int32 = prop.int32.clip(src.int32);
 		break;
 	case PropertyType::Int64:
-		if(prop.minimum.Int64 || prop.maximum.Int64) {
-			int64 = TRange(getPtrValue(prop.minimum.Int64), getPtrValue(prop.maximum.Int64)).clip(src.int64);
-		} else {
-			int64 = src.int64;
-		}
+		int64 = prop.int64.clip(src.int64);
 		break;
 	case PropertyType::UInt8:
-		uint8 = clipUInt32(src.uint8);
+		uint8 = prop.uint32.clip(src.uint8);
 		break;
 	case PropertyType::UInt16:
-		uint16 = clipUInt32(src.uint16);
+		uint16 = prop.uint32.clip(src.uint16);
 		break;
 	case PropertyType::UInt32:
-		uint32 = clipUInt32(src.uint32);
+		uint32 = prop.uint32.clip(src.uint32);
 		break;
 	case PropertyType::UInt64:
-		if(prop.minimum.UInt64 || prop.maximum.UInt64) {
-			uint64 = TRange(getPtrValue(prop.minimum.UInt64), getPtrValue(prop.maximum.UInt64)).clip(src.uint64);
-		} else {
-			uint64 = src.uint64;
-		}
+		uint64 = prop.uint64.clip(src.uint64);
 		break;
 	case PropertyType::String:
 		assert(false);

--- a/src/PropertyInfo.cpp
+++ b/src/PropertyInfo.cpp
@@ -33,6 +33,6 @@ String toString(ConfigDB::PropertyType type)
 
 namespace ConfigDB
 {
-const PropertyInfo PropertyInfo::empty PROGMEM{.name = fstr_empty, .defaultValue = fstr_empty};
+const PropertyInfo PropertyInfo::empty PROGMEM{.name = fstr_empty};
 
 } // namespace ConfigDB

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -67,8 +67,8 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 		if(propData.string) {
 			return String(stringPool[propData.string]);
 		}
-		if(info.defaultValue.string) {
-			return *info.defaultValue.string;
+		if(info.minimum.string) {
+			return *info.minimum.string;
 		}
 		return nullptr;
 	}
@@ -77,17 +77,17 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 
 PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uint16_t valueLength)
 {
+	if(!value) {
+		assert(false);
+		return {};
+	}
+
 	if(prop.type == PropertyType::String) {
-		if(!value || (prop.defaultValue.string && *prop.defaultValue.string == value)) {
+		auto defstring = prop.minimum.string;
+		if(defstring && *defstring == value) {
 			return {.string = 0};
 		}
 		return {.string = stringPool.findOrAdd({value, valueLength})};
-	}
-
-	if(!value) {
-		PropertyData dst{};
-		dst.setValue(prop, nullptr);
-		return dst;
 	}
 
 	PropertyData src{};
@@ -116,7 +116,7 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 	}
 
 	PropertyData dst{};
-	dst.setValue(prop, &src);
+	dst.setValue(prop, src);
 	return dst;
 }
 

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -46,7 +46,7 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 	auto& propData = *static_cast<const PropertyData*>(data);
 	switch(info.type) {
 	case PropertyType::Boolean:
-		return propData.b ? "true" : "false";
+		return propData.boolean ? "true" : "false";
 	case PropertyType::Int8:
 		return String(propData.int8);
 	case PropertyType::Int16:
@@ -67,8 +67,8 @@ String Store::getValueString(const PropertyInfo& info, const void* data) const
 		if(propData.string) {
 			return String(stringPool[propData.string]);
 		}
-		if(info.minimum.string) {
-			return *info.minimum.string;
+		if(info.defaultString) {
+			return *info.defaultString;
 		}
 		return nullptr;
 	}
@@ -83,8 +83,7 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 	}
 
 	if(prop.type == PropertyType::String) {
-		auto defstring = prop.minimum.string;
-		if(defstring && *defstring == value) {
+		if(prop.defaultString && *prop.defaultString == value) {
 			return {.string = 0};
 		}
 		return {.string = stringPool.findOrAdd({value, valueLength})};
@@ -94,7 +93,7 @@ PropertyData Store::parseString(const PropertyInfo& prop, const char* value, uin
 
 	switch(prop.type) {
 	case PropertyType::Boolean:
-		return {.b = (valueLength == 4) && memicmp(value, "true", 4) == 0};
+		return {.boolean = (valueLength == 4) && memicmp(value, "true", 4) == 0};
 	case PropertyType::Int8:
 	case PropertyType::Int16:
 	case PropertyType::Int32:

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -38,22 +38,22 @@ public:
 
 	Property getProperty(unsigned index)
 	{
-		return {getStore(), getItemType(), getArray()[index]};
+		return {getStore(), getItemType(), getArray()[index], nullptr};
 	}
 
 	Property addItem()
 	{
-		return {getStore(), getItemType(), getArray().add()};
+		return {getStore(), getItemType(), getArray().add(), nullptr};
 	}
 
 	Property insertItem(unsigned index)
 	{
-		return {getStore(), getItemType(), getArray().insert(index)};
+		return {getStore(), getItemType(), getArray().insert(index), nullptr};
 	}
 
 	PropertyConst getProperty(unsigned index) const
 	{
-		return {getStore(), getItemType(), getArray()[index]};
+		return {getStore(), getItemType(), getArray()[index], nullptr};
 	}
 
 	const PropertyInfo& getItemType() const

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -223,6 +223,9 @@ protected:
 		return getStringId(toString(value));
 	}
 
+	void setPropertyValue(const PropertyInfo& prop, uint16_t offset, const void* value);
+	void setPropertyValue(const PropertyInfo& prop, uint16_t offset, const String& value);
+
 	const ObjectInfo* typeinfoPtr;
 	Object* parent{};
 	uint16_t dataRef{}; //< Relative to parent

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -40,13 +40,12 @@ union __attribute__((packed)) PropertyData {
 
 	/**
 	 * @brief Range-check raw binary value. Do not use with Strings.
-	 * @param src If null, default will be applied
 	 */
-	void setValue(const PropertyInfo& prop, const PropertyData* src);
+	void setValue(const PropertyInfo& prop, const PropertyData& src);
 };
 
 /**
- * @brief Manages a key/value pair stored in an object
+ * @brief Manages a key/value pair stored in an object, or a simple array value
  */
 class PropertyConst
 {
@@ -60,8 +59,8 @@ public:
 	 * @param info Property information
 	 * @param data Pointer to location where value is stored
 	 */
-	PropertyConst(const Store& store, const PropertyInfo& info, const void* data)
-		: info(&info), store(&store), data(data)
+	PropertyConst(const Store& store, const PropertyInfo& info, const void* data, const void* defaultData)
+		: info(&info), store(&store), data(data), defaultData(defaultData)
 	{
 	}
 
@@ -83,6 +82,7 @@ protected:
 	const PropertyInfo* info;
 	const Store* store{};
 	const void* data{};
+	const void* defaultData{};
 };
 
 class Property : public PropertyConst
@@ -97,6 +97,5 @@ public:
 		return setJsonValue(value.c_str(), value.length());
 	}
 };
-
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -37,6 +37,12 @@ union __attribute__((packed)) PropertyData {
 	bool b;
 	float f;
 	StringId string;
+
+	/**
+	 * @brief Range-check raw binary value. Do not use with Strings.
+	 * @param src If null, default will be applied
+	 */
+	void setValue(const PropertyInfo& prop, const PropertyData* src);
 };
 
 /**
@@ -91,5 +97,6 @@ public:
 		return setJsonValue(value.c_str(), value.length());
 	}
 };
+
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -34,7 +34,7 @@ union __attribute__((packed)) PropertyData {
 	int16_t int16;
 	int32_t int32;
 	int64_t int64;
-	bool b;
+	bool boolean;
 	float f;
 	StringId string;
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -71,6 +71,8 @@ struct PropertyInfo {
 	PropertyType type;
 	const FlashString& name;
 	PropData defaultValue;
+	PropData minimum;
+	PropData maximum;
 
 	static const PropertyInfo empty;
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -55,9 +55,22 @@ using StringId = uint16_t;
  * @brief Property metadata
  */
 struct PropertyInfo {
+	union PropData {
+		int32_t Boolean;
+		int32_t Int8;
+		int32_t Int16;
+		int32_t Int32;
+		int64_t* Int64;
+		uint32_t UInt8;
+		uint32_t UInt16;
+		uint32_t UInt32;
+		uint64_t* UInt64;
+		const FlashString* string;
+	};
+
 	PropertyType type;
 	const FlashString& name;
-	const FlashString& defaultValue;
+	PropData defaultValue;
 
 	static const PropertyInfo empty;
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -70,8 +70,7 @@ struct PropertyInfo {
 
 	PropertyType type;
 	const FlashString& name;
-	PropData defaultValue;
-	PropData minimum;
+	PropData minimum; ///< Default for string
 	PropData maximum;
 
 	static const PropertyInfo empty;

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <WString.h>
+#include <Data/Range.h>
 
 /**
  * @brief Property types with storage size
@@ -55,23 +56,37 @@ using StringId = uint16_t;
  * @brief Property metadata
  */
 struct PropertyInfo {
-	union PropData {
-		int32_t Boolean;
-		int32_t Int8;
-		int32_t Int16;
-		int32_t Int32;
-		const int64_t* Int64;
-		uint32_t UInt8;
-		uint32_t UInt16;
-		uint32_t UInt32;
-		const uint64_t* UInt64;
-		const FlashString* string;
-	};
+	template <typename T> struct RangeTemplate {
+		T minimum;
+		T maximum;
 
+		T clip(T value) const
+		{
+			return TRange(minimum, maximum).clip(value);
+		}
+	};
+	template <typename T> struct RangePtrTemplate {
+		const T* minimum;
+		const T* maximum;
+
+		T clip(T value) const
+		{
+			if(minimum || maximum) {
+				return TRange(minimum ? *minimum : 0, maximum ? *maximum : 0).clip(value);
+			}
+			return value;
+		}
+	};
 	PropertyType type;
 	const FlashString& name;
-	PropData minimum; ///< Default for string
-	PropData maximum;
+	// Variant property information depends on type
+	union {
+		const FlashString* defaultString;
+		RangeTemplate<int32_t> int32;
+		RangeTemplate<uint32_t> uint32;
+		RangePtrTemplate<int64_t> int64;
+		RangePtrTemplate<uint64_t> uint64;
+	};
 
 	static const PropertyInfo empty;
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -60,11 +60,11 @@ struct PropertyInfo {
 		int32_t Int8;
 		int32_t Int16;
 		int32_t Int32;
-		int64_t* Int64;
+		const int64_t* Int64;
 		uint32_t UInt8;
 		uint32_t UInt16;
 		uint32_t UInt32;
-		uint64_t* UInt64;
+		const uint64_t* UInt64;
 		const FlashString* string;
 	};
 

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -3,6 +3,8 @@
  */
 
 #include <ConfigDBTest.h>
+#include <test-config-range.h>
+#include <ConfigDB/Json/Format.h>
 
 class UpdateTest : public TestGroup
 {
@@ -50,6 +52,23 @@ public:
 			} else {
 				TEST_ASSERT(false);
 			}
+		}
+
+		TEST_CASE("Int64")
+		{
+			TestConfigRange db(F("out/test-range"));
+			db.openStore(0, true)->clear();
+			TestConfigRange::Root root(db);
+			REQUIRE_EQ(root.getInt64val(), -1);
+			if(auto update = root.update()) {
+				update.setInt64val(-100000000001LL);
+				REQUIRE_EQ(root.getInt64val(), -100000000000LL);
+				update.setInt64val(100000000001LL);
+				REQUIRE_EQ(root.getInt64val(), 100000000000LL);
+			} else {
+				TEST_ASSERT(false);
+			}
+			db.exportToStream(ConfigDB::Json::format, Serial);
 		}
 	}
 };

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -17,19 +17,39 @@ public:
 		// Verify initial value
 		TestConfig::Root root(database);
 		Serial << root << endl;
-		String s = root.getSimpleString();
-		DEFINE_FSTR_LOCAL(donkey, "donkey")
-		REQUIRE_EQ(s, donkey);
 
-		// Change value
-		if(auto updater = root.update()) {
-			DEFINE_FSTR_LOCAL(banana, "banana")
-			updater.setSimpleString(banana);
-			REQUIRE_EQ(updater.getSimpleString(), banana);
-			updater.setSimpleString(nullptr);
-			REQUIRE_EQ(updater.getSimpleString(), donkey);
-		} else {
-			TEST_ASSERT(false);
+		TEST_CASE("String")
+		{
+			String s = root.getSimpleString();
+			DEFINE_FSTR_LOCAL(donkey, "donkey")
+			REQUIRE_EQ(s, donkey);
+
+			// Change value
+			if(auto updater = root.update()) {
+				DEFINE_FSTR_LOCAL(banana, "banana")
+				updater.setSimpleString(banana);
+				REQUIRE_EQ(updater.getSimpleString(), banana);
+				updater.setSimpleString(nullptr);
+				REQUIRE_EQ(updater.getSimpleString(), donkey);
+			} else {
+				TEST_ASSERT(false);
+			}
+		}
+
+		TEST_CASE("Integer")
+		{
+			REQUIRE_EQ(root.getSimpleInt(), -1);
+
+			// Change value
+			if(auto updater = root.update()) {
+				// Check clipping
+				updater.setSimpleInt(101);
+				REQUIRE_EQ(root.getSimpleInt(), 100);
+				updater.setSimpleInt(-6);
+				REQUIRE_EQ(root.getSimpleInt(), -5);
+			} else {
+				TEST_ASSERT(false);
+			}
 		}
 	}
 };

--- a/test/resource/root1.json
+++ b/test/resource/root1.json
@@ -1,1 +1,1 @@
-{"int_array":[],"string_array":[],"object_array":[],"simple-bool":true,"simple-string":"donkey","simple-int":-1}
+{"int_array":[],"string_array":[],"object_array":[],"simple-bool":true,"simple-string":"donkey","simple-int":100}

--- a/test/resource/update1.json
+++ b/test/resource/update1.json
@@ -1,1 +1,4 @@
-{"simple-bool": true}
+{
+    "simple-bool": true,
+    "simple-int": 101
+}

--- a/test/test-config-range.cfgdb
+++ b/test/test-config-range.cfgdb
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "intval": {
+      "type": "integer",
+      "minimum": -5,
+      "maximum": 100,
+      "default": -1
+    },
+    "int64val": {
+      "type": "integer",
+      "minimum": -100000000000,
+      "maximum": 100000000000,
+      "default": -1
+    }
+  }
+}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -509,6 +509,13 @@ def generate_typeinfo(obj: Object) -> CodeLines:
             return f'{{.string = &{fstr}}}'
         return f'{{.{prop.property_type} = {value}}}'
 
+    def getPropRange(prop: Property):
+        r = prop.get_intrange()
+        return [
+            getPropData(prop, r.minimum),
+            getPropData(prop, r.maximum)
+        ] if r else []
+
     lines.source += [
         '',
         f'const ObjectInfo {obj.namespace}::{obj.typename_contained}::typeinfo PROGMEM',
@@ -529,6 +536,7 @@ def generate_typeinfo(obj: Object) -> CodeLines:
                 f'PropertyType::{prop.property_type}',
                 'fstr_empty' if obj.is_array else strings[prop.name],
                 getPropData(prop, prop.default_str),
+                *getPropRange(prop)
             ], ',') for prop in propinfo),
             '}',
         ] if propinfo else None,

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -510,6 +510,8 @@ def generate_typeinfo(obj: Object) -> CodeLines:
         return f'{{.{prop.property_type} = {value}}}'
 
     def getPropRange(prop: Property):
+        if prop.ptype == 'string':
+            return [getPropData(prop, prop.default_str)]
         r = prop.get_intrange()
         return [
             getPropData(prop, r.minimum),
@@ -535,7 +537,6 @@ def generate_typeinfo(obj: Object) -> CodeLines:
             *(make_static_initializer([
                 f'PropertyType::{prop.property_type}',
                 'fstr_empty' if obj.is_array else strings[prop.name],
-                getPropData(prop, prop.default_str),
                 *getPropRange(prop)
             ], ',') for prop in propinfo),
             '}',

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -82,6 +82,13 @@ class Property:
     name: str
     fields: dict
 
+    def validate(self):
+        r = self.get_intrange()
+        if not r:
+            return
+        if not (r.minimum <= self.default <= r.maximum):
+            raise ValueError(f'{self.name} bad default {self.default}: {r.minimum} <= value <= {r.maximum}')
+
     @property
     def ptype(self):
         return self.fields['type']
@@ -344,6 +351,7 @@ def load_config(filename: str) -> Database:
             if not prop.ctype:
                 print(f'*** "{parent.path}": {prop.ptype} type not yet implemented.')
                 continue
+            prop.validate()
             if prop.ctype != '-': # object or array
                 parent.properties.append(prop)
                 continue


### PR DESCRIPTION
This PR ensures property values are clipped to the defined minimum/maximum range, for both `Updater` and streaming.

A variant (union) field has been added to `PropertyInfo`:

- For integers, this contains valid range (minimum, maximum). 64-bit values are store as optional pointers to reduce bloat
- For strings, this contains the default string

Other types obtain their default value from the object structure.

TODO:

* [x] Generate default, minimum, maximum for int64/uint64 values
* [x] Update tests
