### PR TITLE
Add enum support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -383,6 +383,37 @@ There is also :cpp:class:`ConfigDB::const_number_t` to ease support for format c
 at compile time.
 
 
+Enumerated properties
+---------------------
+
+.. highlight: json
+
+JsonSchema offers the `enum <https://json-schema.org/understanding-json-schema/reference/enum>`__ keyword to restrict values to a set of known values. For example::
+
+  {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "color": {
+        "type": "string",
+        "enum": [
+          "red",
+          "green",
+          "blue"
+        ]
+      }
+    }
+  }
+
+ConfigDB treats these as an *indexed map*, so *red* has the index 0, *green* is 1 and *blue* 2. Indices are of type *uint8_t*. The example has an intrinsic *minimum* of 0 and *maximum* of 2. As with other numeric properties, attempting to set values outside this range are clipped.
+
+The default is 0 (the first string in the list). If a default value is given in the schema, it must match an item in the *enum* array.
+
+The corresponding `setColor`, `getColor` methods set or retrieve the value as a number. Adding *"ctype": "Color"* to the property will generate an *enum class* definition instead. This is the preferred approach.
+
+The *color* value itself will be stored as a *string* with one of the given values. The *integer* and *number* types are also supported, which can be useful for generating constant lookup tables.
+
+
 API Reference
 -------------
 

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -38,10 +38,9 @@ String PropertyConst::getJsonValue() const
 	if(!value) {
 		return "null";
 	}
-	if(propinfo->type != PropertyType::String) {
-		return value;
+	if(propinfo->isStringType()) {
+		::Format::json.quote(value);
 	}
-	::Format::json.quote(value);
 	return value;
 }
 

--- a/src/PropertyData.cpp
+++ b/src/PropertyData.cpp
@@ -27,6 +27,8 @@ String PropertyData::getString(const PropertyInfo& info) const
 	switch(info.type) {
 	case PropertyType::Boolean:
 		return boolean ? "true" : "false";
+	case PropertyType::Enum:
+		return info.variant.enuminfo->getString(uint8);
 	case PropertyType::Int8:
 		return String(int8);
 	case PropertyType::Int16:
@@ -58,6 +60,9 @@ void PropertyData::setValue(const PropertyInfo& prop, const PropertyData& src)
 	switch(prop.type) {
 	case PropertyType::Boolean:
 		boolean = src.boolean;
+		break;
+	case PropertyType::Enum:
+		uint8 = src.uint8;
 		break;
 	case PropertyType::Int8:
 		int8 = prop.variant.int32.clip(src.int8);
@@ -133,6 +138,7 @@ bool PropertyData::setValue(PropertyType type, const char* value, unsigned value
 		}
 		return false;
 	}
+	case PropertyType::Enum:
 	case PropertyType::String:
 	case PropertyType::Object:
 		break;
@@ -143,6 +149,15 @@ bool PropertyData::setValue(PropertyType type, const char* value, unsigned value
 
 bool PropertyData::setValue(const PropertyInfo& prop, const char* value, unsigned valueLength)
 {
+	if(prop.type == PropertyType::Enum) {
+		int i = prop.variant.enuminfo->find(value, valueLength);
+		if(i < 0) {
+			return false;
+		}
+		uint8 = uint8_t(i);
+		return true;
+	}
+
 	PropertyData src{};
 	if(!src.setValue(prop.type, value, valueLength)) {
 		return false;

--- a/src/PropertyData.cpp
+++ b/src/PropertyData.cpp
@@ -62,7 +62,7 @@ void PropertyData::setValue(const PropertyInfo& prop, const PropertyData& src)
 		boolean = src.boolean;
 		break;
 	case PropertyType::Enum:
-		uint8 = src.uint8;
+		uint8 = std::min(unsigned(src.uint8), prop.variant.enuminfo->length() - 1);
 		break;
 	case PropertyType::Int8:
 		int8 = prop.variant.int32.clip(src.int8);

--- a/src/PropertyData.cpp
+++ b/src/PropertyData.cpp
@@ -150,6 +150,10 @@ bool PropertyData::setValue(PropertyType type, const char* value, unsigned value
 bool PropertyData::setValue(const PropertyInfo& prop, const char* value, unsigned valueLength)
 {
 	if(prop.type == PropertyType::Enum) {
+		if(!value) {
+			uint8 = 0;
+			return true;
+		}
 		int i = prop.variant.enuminfo->find(value, valueLength);
 		if(i < 0) {
 			return false;

--- a/src/PropertyInfo.cpp
+++ b/src/PropertyInfo.cpp
@@ -18,6 +18,7 @@
  ****/
 
 #include "include/ConfigDB/PropertyInfo.h"
+#include "include/ConfigDB/PropertyData.h"
 
 String toString(ConfigDB::PropertyType type)
 {
@@ -34,5 +35,74 @@ String toString(ConfigDB::PropertyType type)
 namespace ConfigDB
 {
 const PropertyInfo PropertyInfo::empty PROGMEM{.name = fstr_empty};
+
+String EnumInfo::getString(uint8_t index) const
+{
+	switch(type) {
+	case PropertyType::Int8:
+		return String(getValue<int8_t>(index));
+	case PropertyType::Int16:
+		return String(getValue<int16_t>(index));
+	case PropertyType::Int32:
+		return String(getValue<int32_t>(index));
+	case PropertyType::Int64:
+		return String(getValue<int64_t>(index));
+	case PropertyType::UInt8:
+		return String(getValue<uint8_t>(index));
+	case PropertyType::UInt16:
+		return String(getValue<uint16_t>(index));
+	case PropertyType::UInt32:
+		return String(getValue<uint32_t>(index));
+	case PropertyType::UInt64:
+		return String(getValue<uint64_t>(index));
+	case PropertyType::Number:
+		return toString(getValue<number_t>(index));
+	case PropertyType::String:
+		return getStrings()[index];
+	case PropertyType::Boolean:
+	case PropertyType::Enum:
+	case PropertyType::Object:
+		break;
+	}
+	assert(false);
+	return nullptr;
+}
+
+int EnumInfo::find(const char* value, unsigned length) const
+{
+	if(type == PropertyType::String) {
+		return getStrings().indexOf(value, length);
+	}
+
+	PropertyData d{};
+	d.setValue(type, value, length);
+	switch(type) {
+	case PropertyType::Int8:
+		return getArray<int8_t>().indexOf(d.int8);
+	case PropertyType::Int16:
+		return getArray<int16_t>().indexOf(d.int16);
+	case PropertyType::Int32:
+		return getArray<int32_t>().indexOf(d.int32);
+	case PropertyType::Int64:
+		return getArray<int64_t>().indexOf(d.int64);
+	case PropertyType::UInt8:
+		return getArray<uint8_t>().indexOf(d.uint8);
+	case PropertyType::UInt16:
+		return getArray<uint16_t>().indexOf(d.uint16);
+	case PropertyType::UInt32:
+		return getArray<uint32_t>().indexOf(d.uint32);
+	case PropertyType::UInt64:
+		return getArray<uint64_t>().indexOf(d.uint64);
+	case PropertyType::Number:
+		return getArray<number_t>().indexOf(d.number);
+	case PropertyType::String:
+	case PropertyType::Boolean:
+	case PropertyType::Enum:
+	case PropertyType::Object:
+		break;
+	}
+	assert(false);
+	return -1;
+}
 
 } // namespace ConfigDB

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -96,12 +96,8 @@ bool Store::parseString(const PropertyInfo& prop, PropertyData& dst, const Prope
 		return true;
 	}
 
-	if(!value) {
-		if(defaultData) {
-			memcpy_P(&dst.int8, defaultData, prop.getSize());
-		} else {
-			memset(&dst.int8, 0, prop.getSize());
-		}
+	if(!value && defaultData) {
+		memcpy_P(&dst.int8, defaultData, prop.getSize());
 		return true;
 	}
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -60,9 +60,31 @@ using StringId = uint16_t;
 
 struct ObjectInfo;
 
+inline uint8_t getPropertySize(PropertyType type)
+{
+	switch(type) {
+#define XX(tag, size)                                                                                                  \
+	case PropertyType::tag:                                                                                            \
+		return size;
+		CONFIGDB_PROPERTY_TYPE_MAP(XX)
+#undef XX
+	}
+	return 0;
+}
+
 struct EnumInfo {
 	PropertyType type;		 ///< The actual store type for this enum (String, etc.)
 	FSTR::ObjectBase values; //< Possible values
+
+	uint8_t getItemSize() const
+	{
+		return (type == PropertyType::String) ? sizeof(FSTR::String*) : getPropertySize(type);
+	}
+
+	unsigned length() const
+	{
+		return values.length() / getItemSize();
+	}
 
 	String getString(uint8_t index) const;
 	int find(const char* value, unsigned length) const;
@@ -148,14 +170,7 @@ struct PropertyInfo {
 	 */
 	uint8_t getSize() const
 	{
-		switch(type) {
-#define XX(tag, size)                                                                                                  \
-	case PropertyType::tag:                                                                                            \
-		return size;
-			CONFIGDB_PROPERTY_TYPE_MAP(XX)
-#undef XX
-		}
-		return 0;
+		return getPropertySize(type);
 	}
 };
 

--- a/src/include/ConfigDB/PropertyInfo.h
+++ b/src/include/ConfigDB/PropertyInfo.h
@@ -22,6 +22,8 @@
 #include <WString.h>
 #include <Data/Range.h>
 #include "Number.h"
+#include <FlashString/Array.hpp>
+#include <FlashString/Vector.hpp>
 
 /**
  * @brief Property types with storage size
@@ -32,6 +34,7 @@
 	XX(Int16, 2)                                                                                                       \
 	XX(Int32, 4)                                                                                                       \
 	XX(Int64, 8)                                                                                                       \
+	XX(Enum, 1)                                                                                                        \
 	XX(UInt8, 1)                                                                                                       \
 	XX(UInt16, 2)                                                                                                      \
 	XX(UInt32, 4)                                                                                                      \
@@ -56,6 +59,29 @@ enum class PropertyType : uint32_t {
 using StringId = uint16_t;
 
 struct ObjectInfo;
+
+struct EnumInfo {
+	PropertyType type;		 ///< The actual store type for this enum (String, etc.)
+	FSTR::ObjectBase values; //< Possible values
+
+	String getString(uint8_t index) const;
+	int find(const char* value, unsigned length) const;
+
+	template <typename T> const FSTR::Array<T>& getArray() const
+	{
+		return values.as<FSTR::Array<T>>();
+	}
+
+	const FSTR::Vector<FSTR::String>& getStrings() const
+	{
+		return values.as<FSTR::Vector<FSTR::String>>();
+	}
+
+	template <typename T> T getValue(uint8_t index) const
+	{
+		return getArray<T>()[index];
+	}
+};
 
 /**
  * @brief Property metadata
@@ -86,6 +112,7 @@ struct PropertyInfo {
 	union Variant {
 		const FlashString* defaultString;
 		const ObjectInfo* object;
+		const EnumInfo* enuminfo;
 		RangeTemplate<int32_t> int32;
 		RangeTemplate<uint32_t> uint32;
 		RangeTemplate<const_number_t, number_t> number;
@@ -103,6 +130,17 @@ struct PropertyInfo {
 	explicit operator bool() const
 	{
 		return this != &empty;
+	}
+
+	bool isStringType() const
+	{
+		if(type == PropertyType::String) {
+			return true;
+		}
+		if(type == PropertyType::Enum && variant.enuminfo->type == PropertyType::String) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/test/include/modules.h
+++ b/test/include/modules.h
@@ -6,4 +6,5 @@
 	XX(Streaming)                                                                                                      \
 	XX(Union)                                                                                                          \
 	XX(Number)                                                                                                         \
+	XX(Enum)                                                                                                           \
 	XX(Performance)

--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -17,10 +17,12 @@ public:
 		TestConfigEnum db(F("out/test-enum"));
 		db.openStoreForUpdate(0)->clear();
 
-		auto& colorType = TestConfigEnum::Root::Colors::itemtype;
-		auto& quotientType = TestConfigEnum::Root::Quotients::itemtype;
-		auto& smallMapType = TestConfigEnum::Root::SmallMap::itemtype;
-		auto& numberMapType = TestConfigEnum::Root::NumberMap::itemtype;
+		using Root = TestConfigEnum::Root;
+
+		auto& colorType = Root::Colors::itemtype;
+		auto& quotientType = Root::Quotients::itemtype;
+		auto& smallMapType = Root::SmallMap::itemtype;
+		auto& numberMapType = Root::NumberMap::itemtype;
 
 		Serial << "colors[" << colorType.values().length() << "]: " << colorType.values() << endl;
 		Serial << "quotients[" << quotientType.values().length() << "]: " << quotientType.values() << endl;
@@ -29,20 +31,24 @@ public:
 
 		TestConfigEnum::Root root(db);
 		if(auto update = root.update()) {
-			update.colors.addItem(TestConfigEnum::Root::Colors::Item::blue);
+			update.colors.addItem(Root::Colors::Item::blue);
 			for(unsigned i = 0; i < 10; ++i) {
-				update.colors.addItem(os_random() % colorType.values().length());
+				update.colors.addItem(Root::ColorsItem(os_random() % colorType.values().length()));
 			}
 			for(unsigned i = 0; i < 20; ++i) {
-				update.quotients.addItem(os_random() % quotientType.values().length());
+				update.quotients.addItem(Root::QuotientsItem(os_random() % quotientType.values().length()));
 			}
 			for(unsigned i = 0; i < 10; ++i) {
-				update.smallMap.addItem(os_random() % smallMapType.values().length());
+				update.smallMap.addItem(Root::SmallMapItem(os_random() % smallMapType.values().length()));
 			}
 			for(unsigned i = 0; i < 10; ++i) {
-				update.numberMap.addItem(os_random() % numberMapType.values().length());
+				update.numberMap.addItem(Root::NumberMapItem(os_random() % numberMapType.values().length()));
 			}
 		}
+		for(unsigned i = 0; i < 10; ++i) {
+			Serial << i << ": " << unsigned(root.numberMap[i]) << " " << String(numberMapType.values()[i], 8) << endl;
+		}
+
 		Serial << "root: " << root << endl;
 	}
 };

--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -1,0 +1,52 @@
+/*
+ * Update.cpp
+ */
+
+#include <ConfigDBTest.h>
+#include <test-config-enum.h>
+
+class EnumTest : public TestGroup
+{
+public:
+	EnumTest() : TestGroup(_F("Enum"))
+	{
+	}
+
+	void execute() override
+	{
+		TestConfigEnum db(F("out/test-enum"));
+		db.openStoreForUpdate(0)->clear();
+
+		auto& colorType = TestConfigEnum::Root::Colors::itemtype;
+		auto& quotientType = TestConfigEnum::Root::Quotients::itemtype;
+		auto& smallMapType = TestConfigEnum::Root::SmallMap::itemtype;
+		auto& numberMapType = TestConfigEnum::Root::NumberMap::itemtype;
+
+		Serial << "colors[" << colorType.values().length() << "]: " << colorType.values() << endl;
+		Serial << "quotients[" << quotientType.values().length() << "]: " << quotientType.values() << endl;
+		Serial << "smallMap[" << smallMapType.values().length() << "]: " << smallMapType.values() << endl;
+		Serial << "numberMap[" << numberMapType.values().length() << "]: " << numberMapType.values() << endl;
+
+		TestConfigEnum::Root root(db);
+		if(auto update = root.update()) {
+			for(unsigned i = 0; i < 10; ++i) {
+				update.colors.addItem(os_random() % colorType.values().length());
+			}
+			for(unsigned i = 0; i < 20; ++i) {
+				update.quotients.addItem(os_random() % quotientType.values().length());
+			}
+			for(unsigned i = 0; i < 10; ++i) {
+				update.smallMap.addItem(os_random() % smallMapType.values().length());
+			}
+			for(unsigned i = 0; i < 10; ++i) {
+				update.numberMap.addItem(os_random() % numberMapType.values().length());
+			}
+		}
+		Serial << "root: " << root << endl;
+	}
+};
+
+void REGISTER_TEST(Enum)
+{
+	registerGroup<EnumTest>();
+}

--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -29,6 +29,7 @@ public:
 
 		TestConfigEnum::Root root(db);
 		if(auto update = root.update()) {
+			update.colors.addItem(TestConfigEnum::Root::Colors::Item::blue);
 			for(unsigned i = 0; i < 10; ++i) {
 				update.colors.addItem(os_random() % colorType.values().length());
 			}

--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -31,7 +31,8 @@ public:
 
 		TestConfigEnum::Root root(db);
 		if(auto update = root.update()) {
-			update.colors.addItem(Root::Colors::Item::blue);
+			update.colors.addItem(Root::ColorsItem(100));
+			REQUIRE(update.colors[0] == Root::ColorsItem::blue);
 			for(unsigned i = 0; i < 10; ++i) {
 				update.colors.addItem(Root::ColorsItem(os_random() % colorType.values().length()));
 			}
@@ -44,9 +45,6 @@ public:
 			for(unsigned i = 0; i < 10; ++i) {
 				update.numberMap.addItem(Root::NumberMapItem(os_random() % numberMapType.values().length()));
 			}
-		}
-		for(unsigned i = 0; i < 10; ++i) {
-			Serial << i << ": " << unsigned(root.numberMap[i]) << " " << String(numberMapType.values()[i], 8) << endl;
 		}
 
 		Serial << "root: " << root << endl;

--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -31,19 +31,19 @@ public:
 
 		TestConfigEnum::Root root(db);
 		if(auto update = root.update()) {
-			update.colors.addItem(Root::ColorsItem(100));
-			REQUIRE(update.colors[0] == Root::ColorsItem::blue);
+			update.colors.addItem(Root::Color(100));
+			REQUIRE(update.colors[0] == Root::Color::blue);
 			for(unsigned i = 0; i < 10; ++i) {
-				update.colors.addItem(Root::ColorsItem(os_random() % colorType.values().length()));
+				update.colors.addItem(Root::Color(os_random() % colorType.values().length()));
 			}
 			for(unsigned i = 0; i < 20; ++i) {
-				update.quotients.addItem(Root::QuotientsItem(os_random() % quotientType.values().length()));
+				update.quotients.addItem(Root::Quotient(os_random() % quotientType.values().length()));
 			}
 			for(unsigned i = 0; i < 10; ++i) {
-				update.smallMap.addItem(Root::SmallMapItem(os_random() % smallMapType.values().length()));
+				update.smallMap.addItem(os_random() % smallMapType.values().length());
 			}
 			for(unsigned i = 0; i < 10; ++i) {
-				update.numberMap.addItem(Root::NumberMapItem(os_random() % numberMapType.values().length()));
+				update.numberMap.addItem(os_random() % numberMapType.values().length());
 			}
 		}
 

--- a/test/resource/root1.json
+++ b/test/resource/root1.json
@@ -1,1 +1,1 @@
-{"int_array":[],"string_array":[],"object_array":[],"simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}
+{"int_array":[],"string_array":[],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}

--- a/test/test-config-enum.cfgdb
+++ b/test/test-config-enum.cfgdb
@@ -12,6 +12,7 @@
       "type": "array",
       "items": {
         "type": "integer",
+        "ctype": "Quotient",
         "enum": [
           15,
           37,
@@ -57,6 +58,7 @@
   "$defs": {
     "Color": {
       "type": "string",
+      "ctype": "Color",
       "enum": [
         "red",
         "green",

--- a/test/test-config-enum.cfgdb
+++ b/test/test-config-enum.cfgdb
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "color": {
+      "$ref": "#/$defs/Color"
+    },
     "colors": {
       "type": "array",
       "items": {

--- a/test/test-config-enum.cfgdb
+++ b/test/test-config-enum.cfgdb
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "colors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Color"
+      }
+    },
+    "quotients": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "enum": [
+          15,
+          37,
+          1445,
+          889,
+          2500,
+          45000,
+          180000,
+          650000,
+          25000000,
+          12000000000
+        ]
+      }
+    },
+    "small-map": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "enum": [
+          5,
+          1,
+          6,
+          8,
+          -12
+        ]
+      }
+    },
+    "number-map": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "enum": [
+          3.5,
+          -12e8,
+          5.4,
+          0.1,
+          0.000001,
+          1
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "Color": {
+      "type": "string",
+      "enum": [
+        "red",
+        "green",
+        "blue"
+      ]
+    }
+  }
+}

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "color": {
+      "type": "string",
+      "ctype": "Color",
+      "enum": [
+        "red",
+        "green",
+        "blue"
+      ]
+    },
     "simple-bool": {
       "type": "boolean"
     },

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -810,6 +810,7 @@ def generate_typeinfo(obj: Object) -> CodeLines:
             values = prop.enum
             obj_type = f'{obj.namespace}::{obj.typename_contained}'
             item_type = 'const FSTR::String*' if prop.enum_type == 'String' else prop.enum_ctype
+            tag_prefix = '' if prop.enum_type == 'String' else  'N'
             lines.header += [
                 '',
                 'struct ItemType {',
@@ -834,6 +835,9 @@ def generate_typeinfo(obj: Object) -> CodeLines:
                 '',
                 'static const ItemType itemtype;',
                 '',
+                'enum class Item {',
+                [f'{tag_prefix}{make_identifier(str(x))},' for x in values],
+                '};'
             ]
             lines.source += [
                 '',

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -198,6 +198,11 @@ class Property:
                 self.enum_ctype = 'const_number_t'
             else:
                 error(f'Unsupported enum type "{self.ptype}"')
+            if self.default:
+                if self.default not in self.enum:
+                    error(f'default "{self.default}" not in enum')
+            else:
+                self.default = self.enum[0]
             self.ptype = 'integer'
             self.property_type = 'Enum'
             self.ctype = 'uint8_t'

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -206,7 +206,6 @@ class Property:
             self.ptype = 'integer'
             self.property_type = 'Enum'
             self.ctype = 'uint8_t'
-            self.ctype_override = f'{obj.typename}Item'
 
     @property
     def ctype_ret(self):
@@ -811,9 +810,12 @@ def generate_typeinfo(obj: Object) -> CodeLines:
             values = prop.enum
             obj_type = f'{obj.namespace}::{obj.typename_contained}'
             item_type = 'const FSTR::String*' if prop.enum_type == 'String' else prop.enum_ctype
+            if prop.ctype_override:
+                lines.header += [
+                    '',
+                    f'using Item = {prop.ctype_override};'
+                ]
             lines.header += [
-                '',
-                f'using Item = {prop.ctype_override};',
                 '',
                 'struct ItemType {',
                 [
@@ -1071,7 +1073,7 @@ def generate_object(obj: Object) -> CodeLines:
             item_lines.source + typeinfo.source)
 
     if isinstance(obj, Array):
-        if obj.items.enum:
+        if obj.items.enum and obj.items.ctype_override:
             prop = obj.items
             tag_prefix = '' if prop.enum_type == 'String' else  'N'
             enum_item = [


### PR DESCRIPTION
This PR implements support for the `enum` keyword as outlined in issue #13.

JsonSchema offers the `enum <https://json-schema.org/understanding-json-schema/reference/enum>`__ keyword to restrict values to a set of known values. For example:

```json
  {
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object",
    "properties": {
      "color": {
        "type": "string",
        "enum": [
          "red",
          "green",
          "blue"
        ]
      }
    }
  }
```

ConfigDB treats these as an *indexed map*, so *red* has the index 0, *green* is 1 and *blue* 2. Indices are of type *uint8_t*. The example has an intrinsic *minimum* of 0 and *maximum* of 2. As with other numeric properties, attempting to set values outside this range are clipped.

The default is 0 (the first string in the list). If a default value is given in the schema, it must match an item in the *enum* array.

The corresponding `setColor`, `getColor` methods set or retrieve the value as a number. Adding *"ctype": "Color"* to the property will generate an *enum class* definition instead. This is the preferred approach.

The *color* value itself will be stored as a *string* with one of the given values. The *integer* and *number* types are also supported, which can be useful for generating constant lookup tables.
