### PR TITLE
Fix Store caching

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -111,10 +111,7 @@ StoreRef Database::openStore(unsigned index)
 StoreUpdateRef Database::openStoreForUpdate(unsigned index)
 {
 	auto store = openStore(index);
-	if(lockStore(store)) {
-		return store;
-	}
-	return {};
+	return lockStore(store);
 }
 
 StoreUpdateRef Database::lockStore(StoreRef& store)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -189,11 +189,11 @@ std::shared_ptr<Store> Database::loadStore(const PropertyInfo& storeInfo)
 	return store;
 }
 
-void Database::queueUpdate(Store& store, Object::UpdateCallback callback)
+void Database::queueUpdate(Store& store, Object::UpdateCallback&& callback)
 {
 	int storeIndex = typeinfo.indexOf(store.propinfo());
 	assert(storeIndex >= 0);
-	updateQueue.add({uint8_t(storeIndex), callback});
+	updateQueue.add({uint8_t(storeIndex), std::move(callback)});
 }
 
 void Database::checkStoreRef(const StoreRef& ref)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -168,16 +168,15 @@ std::shared_ptr<Store> Database::loadStore(const PropertyInfo& storeInfo)
 {
 	debug_i("[CFGDB] LoadStore '%s'", String(storeInfo.name).c_str());
 
-	auto store = std::make_shared<Store>(*this, storeInfo);
+	StoreRef store = std::make_shared<Store>(*this, storeInfo);
 	if(!store) {
 		return nullptr;
 	}
 
 	auto& format = getFormat(*store);
-	store->incUpdate();
-	store->importFromFile(format);
-	store->clearDirty();
-	store->decUpdate();
+	StoreUpdateRef update = store;
+	update->importFromFile(format);
+	update->clearDirty();
 	return store;
 }
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -273,9 +273,8 @@ bool Database::save(Store& store) const
 	// Update write cache so it contains most recent data
 	auto storeIndex = typeinfo.indexOf(store.propinfo());
 	assert(storeIndex >= 0);
-	auto& weakRef = updateRefs[storeIndex];
-	assert(!weakRef.expired());
-	writeCache.store = weakRef.lock();
+	writeCache.store = updateRefs[storeIndex].lock();
+	assert(&store == writeCache.store.get());
 
 	return result;
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -95,7 +95,7 @@ StoreRef Database::openStore(unsigned index)
 		return readCache.store;
 	}
 
-	// OK, need to load from storage
+	// Need to load from storage
 	readCache.reset();
 	readCache.store = loadStore(storeInfo);
 
@@ -226,11 +226,9 @@ void Database::checkStoreRef(const StoreRef& ref)
 			}
 
 			if(readCache.isIdle()) {
-				debug_i("\r\n\r\n** Flush READ Cache **\r\n\r\n");
 				readCache.reset();
 			}
 			if(writeCache.isIdle()) {
-				debug_i("\r\n\r\n** Flush WRITE Cache **\r\n\r\n");
 				writeCache.reset();
 			}
 		},

--- a/src/Json/Format.cpp
+++ b/src/Json/Format.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<ExportStream> Format::createExportStream(Database& db) const
 	return std::make_unique<ReadStream>(db, pretty);
 }
 
-std::unique_ptr<ExportStream> Format::createExportStream(std::shared_ptr<Store> store, const Object& object) const
+std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const Object& object) const
 {
 	return std::make_unique<ReadStream>(store, object, pretty);
 }
@@ -56,7 +56,7 @@ std::unique_ptr<ImportStream> Format::createImportStream(Database& db) const
 	return std::make_unique<WriteStream>(db);
 }
 
-std::unique_ptr<ImportStream> Format::createImportStream(std::shared_ptr<Store> store, Object& object) const
+std::unique_ptr<ImportStream> Format::createImportStream(StoreUpdateRef& store, Object& object) const
 {
 	return std::make_unique<WriteStream>(store, object);
 }

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -35,7 +35,7 @@ public:
 	{
 	}
 
-	ReadStream(std::shared_ptr<Store> store, const Object& object, bool pretty)
+	ReadStream(StoreRef& store, const Object& object, bool pretty)
 		: store(store), printer(stream, object, pretty, Printer::RootStyle::braces), pretty(pretty)
 	{
 	}
@@ -75,7 +75,7 @@ private:
 	size_t fillStream(Print& p);
 
 	Database* db{};
-	std::shared_ptr<Store> store;
+	StoreRef store;
 	Printer printer;
 	MemoryDataStream stream;
 	bool pretty;

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -146,8 +146,8 @@ bool WriteStream::locateStoreOrRoot(const Element& element)
 	int i = root.object->findObject(element.key, element.keyLength);
 	if(i >= 0) {
 		store.reset();
-		store = database->openStore(0, true);
-		if(!store || !*store) {
+		store = database->openStoreForUpdate(0);
+		if(!store) {
 			return handleError(FormatError::UpdateConflict, element.getKey());
 		}
 		parent = *store;
@@ -164,8 +164,8 @@ bool WriteStream::locateStoreOrRoot(const Element& element)
 	if(i < 0) {
 		return handleError(FormatError::NotInSchema, element.getKey());
 	}
-	store = database->openStore(i, true);
-	if(!store || !*store) {
+	store = database->openStoreForUpdate(i);
+	if(!store) {
 		auto& type = database->typeinfo.stores[i];
 		return handleError(FormatError::UpdateConflict, type.name);
 	}

--- a/src/Json/WriteStream.h
+++ b/src/Json/WriteStream.h
@@ -38,7 +38,7 @@ public:
 	{
 	}
 
-	WriteStream(std::shared_ptr<Store> store, Object& object) : store(store), info{object}, parser(this)
+	WriteStream(StoreUpdateRef& store, Object& object) : store(store), info{object}, parser(this)
 	{
 	}
 
@@ -109,7 +109,7 @@ private:
 
 private:
 	Database* database{};
-	std::shared_ptr<Store> store;
+	StoreUpdateRef store;
 	Object info[JSON::StreamingParser::maxNesting]{};
 	ObjectArray arrayParent; ///< Temporary required when using selectors
 	JSON::StaticStreamingParser<1024> parser;

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -175,7 +175,7 @@ Property Object::findProperty(const char* name, size_t length)
 
 void Object::queueUpdate(UpdateCallback callback)
 {
-	return getStore().queueUpdate(callback);
+	return getStore().queueUpdate(std::move(callback));
 }
 
 bool Object::commit()

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -33,34 +33,32 @@ Object& Object::operator=(const Object& other)
 	return *this;
 }
 
-std::shared_ptr<Store> Object::openStore(Database& db, unsigned storeIndex, bool lockForWrite)
+StoreRef Object::openStore(Database& db, unsigned storeIndex)
 {
-	return db.openStore(storeIndex, lockForWrite);
+	return db.openStore(storeIndex);
 }
 
-bool Object::lockStore(std::shared_ptr<Store>& store)
+StoreUpdateRef Object::openStoreForUpdate(Database& db, unsigned storeIndex)
 {
-	if(store->isLocked()) {
-		store->incUpdate();
-		return true;
-	}
+	return db.openStoreForUpdate(storeIndex);
+}
+
+StoreUpdateRef Object::lockStore(StoreRef& store)
+{
 	// Get root object which has pointer to Store: this may change
 	auto obj = this;
 	while(!obj->parent->typeIs(ObjectType::Store)) {
 		obj = obj->parent;
 	}
 	assert(obj->parent);
-	// Update store pointer
-	if(!store->getDatabase().lockStore(store)) {
-		return false;
-	}
-	obj->parent = store.get();
-	return true;
-}
 
-void Object::unlockStore(Store& store)
-{
-	store.decUpdate();
+	// Update store pointer
+	auto update = store->getDatabase().lockStore(store);
+	if(!update){
+		return {};
+	}
+	obj->parent = update.get();
+	return update;
 }
 
 Store& Object::getStore()
@@ -74,9 +72,13 @@ Store& Object::getStore()
 	return *store;
 }
 
-bool Object::isLocked() const
+bool Object::isWriteable() const
 {
-	return getStore().isLocked();
+	if(!getStore().isLocked()) {
+		return false;
+	}
+	auto ptr = getDataPtr();
+	return ptr != nullptr;
 }
 
 bool Object::writeCheck() const

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -54,10 +54,9 @@ StoreUpdateRef Object::lockStore(StoreRef& store)
 
 	// Update store pointer
 	auto update = store->getDatabase().lockStore(store);
-	if(!update){
-		return {};
+	if(update) {
+		obj->parent = update.get();
 	}
-	obj->parent = update.get();
 	return update;
 }
 

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -97,6 +97,12 @@ void Store::queueUpdate(Object::UpdateCallback callback)
 	return db.queueUpdate(*this, callback);
 }
 
+void Store::incUpdate()
+{
+	++updaterCount;
+	CFGDB_DEBUG(" %u", updaterCount)
+}
+
 void Store::decUpdate()
 {
 	if(updaterCount == 0) {

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -24,6 +24,31 @@ namespace ConfigDB
 {
 uint8_t Store::instanceCount;
 
+Store::Store(Database& db, const PropertyInfo& propinfo)
+	: Object(propinfo), db(db), rootData(std::make_unique<uint8_t[]>(propinfo.object->structSize))
+{
+	memcpy_P(rootData.get(), propinfo.object->defaultData, propinfo.object->structSize);
+	++instanceCount;
+	CFGDB_DEBUG(" %u", instanceCount)
+}
+
+Store::Store(const Store& store)
+	: Object(store.propinfo()), arrayPool(store.arrayPool), stringPool(store.stringPool), db(store.db),
+	  rootData(std::make_unique<uint8_t[]>(store.typeinfo().structSize))
+{
+	++instanceCount;
+	CFGDB_DEBUG(" COPY %u", instanceCount)
+	memcpy(rootData.get(), store.rootData.get(), typeinfo().structSize);
+}
+
+Store::~Store()
+{
+	if(*this) {
+		--instanceCount;
+		CFGDB_DEBUG(" %u", instanceCount);
+	}
+}
+
 void Store::clear()
 {
 	auto& root = typeinfo();

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -122,6 +122,11 @@ void Store::queueUpdate(Object::UpdateCallback callback)
 	return db.queueUpdate(*this, callback);
 }
 
+void Store::checkRef(const StoreRef& ref)
+{
+	db.checkStoreRef(ref);
+}
+
 void Store::incUpdate()
 {
 	++updaterCount;

--- a/src/Store.cpp
+++ b/src/Store.cpp
@@ -117,9 +117,9 @@ bool Store::writeCheck() const
 	return false;
 }
 
-void Store::queueUpdate(Object::UpdateCallback callback)
+void Store::queueUpdate(Object::UpdateCallback&& callback)
 {
-	return db.queueUpdate(*this, callback);
+	return db.queueUpdate(*this, std::move(callback));
 }
 
 void Store::checkRef(const StoreRef& ref)

--- a/src/StoreRef.cpp
+++ b/src/StoreRef.cpp
@@ -24,8 +24,8 @@ namespace ConfigDB
 {
 StoreRef::~StoreRef()
 {
-	if(use_count() == 1) {
-		debug_i("%p %s", this, __FUNCTION__);
+	if(*this) {
+		get()->checkRef(*this);
 	}
 }
 

--- a/src/StoreRef.cpp
+++ b/src/StoreRef.cpp
@@ -29,6 +29,12 @@ StoreRef::~StoreRef()
 	}
 }
 
+StoreRef::operator bool() const
+{
+	auto store = get();
+	return store && *store;
+}
+
 StoreUpdateRef::~StoreUpdateRef()
 {
 	if(*this) {

--- a/src/StoreRef.cpp
+++ b/src/StoreRef.cpp
@@ -1,0 +1,51 @@
+/**
+ * ConfigDB/StoreRef.cpp
+ *
+ * Copyright 2024 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the ConfigDB Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ ****/
+
+#include "include/ConfigDB/StoreRef.h"
+#include "include/ConfigDB/Store.h"
+
+namespace ConfigDB
+{
+StoreRef::~StoreRef()
+{
+	if(use_count() == 1) {
+		debug_i("%p %s", this, __FUNCTION__);
+	}
+}
+
+StoreUpdateRef::~StoreUpdateRef()
+{
+	if(*this) {
+		get()->decUpdate();
+	}
+}
+
+StoreUpdateRef& StoreUpdateRef::operator=(StoreRef& other)
+{
+	if(*this) {
+		get()->decUpdate();
+	}
+	StoreRef::operator=(other);
+	if(*this) {
+		get()->incUpdate();
+	}
+	return *this;
+}
+
+} // namespace ConfigDB

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -55,7 +55,9 @@ public:
 	/**
 	 * @brief Open a store instance, load it and return a shared pointer
 	 */
-	std::shared_ptr<Store> openStore(unsigned index, bool lockForWrite = false);
+	StoreRef openStore(unsigned index);
+
+	StoreUpdateRef openStoreForUpdate(unsigned index);
 
 	void queueUpdate(Store& store, Object::UpdateCallback callback);
 	void checkUpdateQueue(Store& store);
@@ -66,7 +68,7 @@ public:
 	 * @brief Lock a store for writing
 	 * @retval bool Fails if called more than once
 	 */
-	bool lockStore(std::shared_ptr<Store>& store);
+	StoreUpdateRef lockStore(StoreRef& store);
 
 	/**
 	 * @brief Get the storage format to use for a store
@@ -121,6 +123,11 @@ private:
 			return bool(store);
 		}
 
+		bool operator==(const StoreCache& other) const
+		{
+			return store == other.store;
+		}
+
 		void reset()
 		{
 			store.reset();
@@ -129,6 +136,11 @@ private:
 		bool typeIs(const PropertyInfo& storeInfo) const
 		{
 			return store && store->propinfoPtr == &storeInfo;
+		}
+
+		bool inUse() const
+		{
+			return store && store.use_count() > 1;
 		}
 	};
 

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -34,7 +34,7 @@ public:
 	 * @param path Path to root directory where all data is stored
 	 */
 	Database(const DatabaseInfo& typeinfo, const String& path)
-		: typeinfo(typeinfo), path(path.c_str()), updateRefs(new UpdateRef[typeinfo.storeCount])
+		: typeinfo(typeinfo), path(path.c_str()), updateRefs(new WeakRef[typeinfo.storeCount])
 	{
 	}
 
@@ -113,7 +113,7 @@ public:
 	const DatabaseInfo& typeinfo;
 
 private:
-	using UpdateRef = std::weak_ptr<Store>;
+	using WeakRef = std::weak_ptr<Store>;
 
 	struct StoreCache {
 		std::shared_ptr<Store> store;
@@ -161,7 +161,7 @@ private:
 	// Hold store open for a brief period to avoid thrashing
 	static StoreCache readCache;
 	static StoreCache writeCache;
-	std::unique_ptr<UpdateRef[]> updateRefs;
+	std::unique_ptr<WeakRef[]> updateRefs;
 	Vector<UpdateQueueItem> updateQueue;
 	static bool callbackQueued;
 };

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -86,8 +86,9 @@ public:
 
 	/**
 	 * @brief Lock a store for writing (called by Object)
-	 * @param store Store reference to be locked
-	 * @retval StoreUpdateRef Invalid if called more than once
+	 * @param store Store reference to be locked. If possible, will be locked-in place
+	 * otherwise it will be copied and updated.
+	 * @retval StoreUpdateRef Invalid if locking fails
 	 */
 	StoreUpdateRef lockStore(StoreRef& store);
 

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -169,11 +169,6 @@ private:
 			return bool(store);
 		}
 
-		bool operator==(const StoreCache& other) const
-		{
-			return store == other.store;
-		}
-
 		void reset()
 		{
 			store.reset();
@@ -197,7 +192,7 @@ private:
 		/**
 		 * @brief Which store is to be updated
 		 */
-		uint8_t storeIndex; 
+		uint8_t storeIndex;
 
 		/**
 		 * @brief Application-provided callback invoked with updatable Store

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -113,6 +113,25 @@ public:
 private:
 	using UpdateRef = std::weak_ptr<Store>;
 
+	struct StoreCache {
+		std::shared_ptr<Store> store;
+
+		explicit operator bool() const
+		{
+			return bool(store);
+		}
+
+		void reset()
+		{
+			store.reset();
+		}
+
+		bool typeIs(const PropertyInfo& storeInfo) const
+		{
+			return store && store->propinfoPtr == &storeInfo;
+		}
+	};
+
 	struct UpdateQueueItem {
 		uint8_t storeIndex;
 		Object::UpdateCallback callback;
@@ -125,12 +144,11 @@ private:
 
 	std::shared_ptr<Store> loadStore(const PropertyInfo& storeInfo);
 
-	bool isCached(const PropertyInfo& storeInfo) const;
-
 	CString path;
 
 	// Hold store open for a brief period to avoid thrashing
-	static std::shared_ptr<Store> cache;
+	static StoreCache readCache;
+	static StoreCache writeCache;
 	std::unique_ptr<UpdateRef[]> updateRefs;
 	Vector<UpdateQueueItem> updateQueue;
 	static bool callbackQueued;

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -59,6 +59,8 @@ public:
 
 	StoreUpdateRef openStoreForUpdate(unsigned index);
 
+	void checkStoreRef(const StoreRef& ref);
+
 	void queueUpdate(Store& store, Object::UpdateCallback callback);
 	void checkUpdateQueue(Store& store);
 
@@ -138,9 +140,9 @@ private:
 			return store && store->propinfoPtr == &storeInfo;
 		}
 
-		bool inUse() const
+		bool isIdle()
 		{
-			return store && store.use_count() > 1;
+			return store && store.use_count() == 1;
 		}
 	};
 
@@ -163,7 +165,8 @@ private:
 	static StoreCache writeCache;
 	std::unique_ptr<WeakRef[]> updateRefs;
 	Vector<UpdateQueueItem> updateQueue;
-	static bool callbackQueued;
+	bool updateQueued{false};
+	static bool cacheCallbackQueued;
 };
 
 /**

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -21,7 +21,7 @@
 
 #include <Data/Stream/ReadWriteStream.h>
 #include "Status.h"
-#include <memory>
+#include "StoreRef.h"
 
 namespace ConfigDB
 {
@@ -60,8 +60,7 @@ public:
 	 *
 	 * Used for streaming asychronously to a web client, for example in an HttpResponse.
 	 */
-	virtual std::unique_ptr<ExportStream> createExportStream(std::shared_ptr<Store> store,
-															 const Object& object) const = 0;
+	virtual std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object) const = 0;
 
 	/**
 	 * @brief Print object
@@ -88,7 +87,7 @@ public:
 	 *
 	 * Used when updating a store from a remote web client, for example via HttpRequest
 	 */
-	virtual std::unique_ptr<ImportStream> createImportStream(std::shared_ptr<Store> store, Object& object) const = 0;
+	virtual std::unique_ptr<ImportStream> createImportStream(StoreUpdateRef& store, Object& object) const = 0;
 
 	/**
 	 * @brief De-serialise content from stream into object (RAM)

--- a/src/include/ConfigDB/Json/Format.h
+++ b/src/include/ConfigDB/Json/Format.h
@@ -29,11 +29,11 @@ public:
 	DEFINE_FSTR_LOCAL(fileExtension, ".json")
 
 	std::unique_ptr<ExportStream> createExportStream(Database& db) const override;
-	std::unique_ptr<ExportStream> createExportStream(std::shared_ptr<Store> store, const Object& object) const override;
+	std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object) const override;
 	size_t exportToStream(const Object& object, Print& output) const override;
 	size_t exportToStream(Database& database, Print& output) const override;
 	std::unique_ptr<ImportStream> createImportStream(Database& db) const override;
-	std::unique_ptr<ImportStream> createImportStream(std::shared_ptr<Store> store, Object& object) const override;
+	std::unique_ptr<ImportStream> createImportStream(StoreUpdateRef& store, Object& object) const override;
 	Status importFromStream(Object& object, Stream& source) const override;
 	Status importFromStream(Database& database, Stream& source) const override;
 

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -21,6 +21,7 @@
 
 #include "Property.h"
 #include "ObjectInfo.h"
+#include "StoreRef.h"
 #include "Format.h"
 
 namespace ConfigDB
@@ -207,21 +208,12 @@ public:
 	void queueUpdate(UpdateCallback callback);
 
 protected:
-	std::shared_ptr<Store> openStore(Database& db, unsigned storeIndex, bool lockForWrite = false);
+	StoreRef openStore(Database& db, unsigned storeIndex);
+	StoreUpdateRef openStoreForUpdate(Database& db, unsigned storeIndex);
 
-	bool isLocked() const;
+	bool isWriteable() const;
 
-	bool isWriteable() const
-	{
-		if(isLocked()) {
-			assert(getDataPtr());
-		}
-		return isLocked() && getDataPtr();
-	}
-
-	bool lockStore(std::shared_ptr<Store>& store);
-
-	void unlockStore(Store& store);
+	StoreUpdateRef lockStore(StoreRef& store);
 
 	bool writeCheck() const;
 
@@ -296,19 +288,14 @@ template <class UpdaterType, unsigned storeIndex, class ParentClassType, unsigne
 class OuterObjectUpdaterTemplate : public UpdaterType
 {
 public:
-	OuterObjectUpdaterTemplate(std::shared_ptr<Store> store)
+	OuterObjectUpdaterTemplate(StoreUpdateRef store)
 		: UpdaterType(*store, ParentClassType::typeinfo.getObject(propIndex), offset), store(store)
 	{
 	}
 
 	explicit OuterObjectUpdaterTemplate(Database& db)
-		: OuterObjectUpdaterTemplate(this->openStore(db, storeIndex, true))
+		: OuterObjectUpdaterTemplate(this->openStoreForUpdate(db, storeIndex))
 	{
-	}
-
-	~OuterObjectUpdaterTemplate()
-	{
-		this->unlockStore(*store);
 	}
 
 	std::unique_ptr<ImportStream> createImportStream(const Format& format)
@@ -317,7 +304,7 @@ public:
 	}
 
 private:
-	std::shared_ptr<Store> store;
+	StoreUpdateRef store;
 };
 
 /**
@@ -333,7 +320,7 @@ template <class ContainedClassType, class UpdaterType, unsigned storeIndex, clas
 class OuterObjectTemplate : public ContainedClassType
 {
 public:
-	OuterObjectTemplate(std::shared_ptr<Store> store)
+	OuterObjectTemplate(StoreRef store)
 		: ContainedClassType(*store, ParentClassType::typeinfo.getObject(propIndex), offset), store(store)
 	{
 	}
@@ -363,8 +350,7 @@ public:
 	 */
 	OuterUpdater update()
 	{
-		this->lockStore(store);
-		return OuterUpdater(store);
+		return OuterUpdater(this->lockStore(store));
 	}
 
 	/**
@@ -385,7 +371,7 @@ public:
 	}
 
 private:
-	std::shared_ptr<Store> store;
+	StoreRef store;
 };
 
 } // namespace ConfigDB

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -203,8 +203,17 @@ public:
 		return PropertyData::fromStruct(typeinfo().getProperty(index), getDataPtr());
 	}
 
+	/**
+	 * @brief Callback invoked by asynchronous updater
+	 * @param store Updatable store instance
+	 * @note The `OuterObjectTemplate::update` method template handles this callback
+	 * so that the caller receives the appropriate Updater object.
+	 */
 	using UpdateCallback = Delegate<void(Store& store)>;
 
+	/**
+	 * @brief Called from `OuterObjectTemplate::update` to queue an update
+	 */
 	void queueUpdate(UpdateCallback callback);
 
 protected:
@@ -364,7 +373,7 @@ public:
 			callback(upd);
 			return true;
 		}
-		Object::queueUpdate([callback](Store& store) {
+		this->queueUpdate([callback](Store& store) {
 			callback(UpdaterType(store, ParentClassType::typeinfo.getObject(propIndex), offset));
 		});
 		return false;

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -312,6 +312,11 @@ public:
 		return format.createImportStream(store, *this);
 	}
 
+	explicit operator bool() const
+	{
+		return store && UpdaterType::operator bool();
+	}
+
 private:
 	StoreUpdateRef store;
 };

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -58,36 +58,16 @@ public:
 	 * @param db Database which manages this store
 	 * @param typeinfo Store type information
 	 */
-	Store(Database& db, const PropertyInfo& propinfo)
-		: Object(propinfo), db(db), rootData(std::make_unique<uint8_t[]>(propinfo.object->structSize))
-	{
-		memcpy_P(rootData.get(), propinfo.object->defaultData, propinfo.object->structSize);
-		++instanceCount;
-		CFGDB_DEBUG(" %u", instanceCount)
-	}
+	Store(Database& db, const PropertyInfo& propinfo);
 
 	/**
 	 * @brief Copy constructor
 	 */
-	explicit Store(const Store& store)
-		: Object(store.propinfo()), arrayPool(store.arrayPool), stringPool(store.stringPool), db(store.db),
-		  rootData(std::make_unique<uint8_t[]>(store.typeinfo().structSize))
-	{
-		++instanceCount;
-		CFGDB_DEBUG(" COPY %u", instanceCount)
-		memcpy(rootData.get(), store.rootData.get(), typeinfo().structSize);
-	}
+	explicit Store(const Store& store);
 
 	Store(Store&&) = delete;
 
-	~Store()
-	{
-		if(*this) {
-			commit();
-			--instanceCount;
-			CFGDB_DEBUG(" %u", instanceCount);
-		}
-	}
+	~Store();
 
 	String getFileName() const
 	{
@@ -167,12 +147,20 @@ public:
 		return importFromFile(format, filename);
 	}
 
+	bool isDirty() const
+	{
+		return dirty;
+	}
+
 	bool commit();
+
+	static StoreUpdateRef lock(StoreRef& store);
 
 protected:
 	friend class Object;
 	friend class ArrayBase;
 	friend class Database;
+	friend class StoreUpdateRef;
 
 	void queueUpdate(Object::UpdateCallback callback);
 

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -165,7 +165,7 @@ protected:
 
 	void checkRef(const StoreRef& ref);
 
-	void queueUpdate(Object::UpdateCallback callback);
+	void queueUpdate(Object::UpdateCallback&& callback);
 
 	void clearDirty()
 	{

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -159,13 +159,7 @@ public:
 		return exportToFile(format, filename);
 	}
 
-	Status importFromFile(const Format& format, const String& filename)
-	{
-		incUpdate();
-		auto result = Object::importFromFile(format, filename);
-		decUpdate();
-		return result;
-	}
+	using Object::importFromFile;
 
 	Status importFromFile(const Format& format)
 	{
@@ -187,11 +181,7 @@ protected:
 		dirty = false;
 	}
 
-	void incUpdate()
-	{
-		++updaterCount;
-		CFGDB_DEBUG(" %u", updaterCount)
-	}
+	void incUpdate();
 
 	void decUpdate();
 

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -160,7 +160,10 @@ protected:
 	friend class Object;
 	friend class ArrayBase;
 	friend class Database;
+	friend class StoreRef;
 	friend class StoreUpdateRef;
+
+	void checkRef(const StoreRef& ref);
 
 	void queueUpdate(Object::UpdateCallback callback);
 

--- a/src/include/ConfigDB/StoreRef.h
+++ b/src/include/ConfigDB/StoreRef.h
@@ -35,6 +35,8 @@ public:
 	}
 
 	~StoreRef();
+
+	explicit operator bool() const;
 };
 
 class StoreUpdateRef : public StoreRef

--- a/src/include/ConfigDB/StoreRef.h
+++ b/src/include/ConfigDB/StoreRef.h
@@ -1,0 +1,60 @@
+/**
+ * ConfigDB/StoreRef.h
+ *
+ * Copyright 2024 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the ConfigDB Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ ****/
+
+#pragma once
+
+#include <memory>
+
+namespace ConfigDB
+{
+class Store;
+
+class StoreRef : public std::shared_ptr<Store>
+{
+public:
+	StoreRef() = default;
+
+	StoreRef(std::shared_ptr<Store> store) : shared_ptr(store)
+	{
+	}
+
+	~StoreRef();
+};
+
+class StoreUpdateRef : public StoreRef
+{
+public:
+	StoreUpdateRef() = default;
+
+	StoreUpdateRef(StoreRef& store)
+	{
+		*this = store;
+	}
+
+	StoreUpdateRef(StoreUpdateRef& store)
+	{
+		*this = static_cast<StoreRef&>(store);
+	}
+
+	~StoreUpdateRef();
+
+	StoreUpdateRef& operator=(StoreRef& other);
+};
+
+} // namespace ConfigDB

--- a/test/app/application.cpp
+++ b/test/app/application.cpp
@@ -13,7 +13,7 @@ TestConfig database("out/test-config");
 
 void resetDatabase()
 {
-	database.openStore(0, true)->clear();
+	database.openStoreForUpdate(0)->clear();
 }
 
 #define XX(t) extern void REGISTER_TEST(t);

--- a/test/modules/Performance.cpp
+++ b/test/modules/Performance.cpp
@@ -42,44 +42,37 @@ public:
 
 		Serial << _F("Evaluating setValue / commit ...") << endl;
 
-		profile(F("setValue [int]"), [](unsigned value) {
+		{
 			TestConfig::Root::OuterUpdater root(database);
-			root.setSimpleInt(value);
-			root.clearDirty();
-		});
 
-		constexpr const double testFloat = PI;
-		profile(F("setValue [float]"), [](unsigned) {
-			TestConfig::Root::OuterUpdater root(database);
-			root.setSimpleFloat(testFloat);
-			root.clearDirty();
-		});
+			profile(F("setValue [int]"), [&](unsigned value) { root.setSimpleInt(value); });
 
-		profile(F("Set Value + commit"), [](unsigned value) {
-			TestConfig::Root::OuterUpdater root(database);
-			root.setSimpleInt(value);
-		});
+			constexpr const double testFloat = PI;
+			profile(F("setValue [float]"), [&](unsigned) { root.setSimpleFloat(testFloat); });
+
+			profile(F("Set Value + commit"), [&](unsigned value) {
+				root.setSimpleInt(value);
+				root.commit();
+			});
+		}
 
 		Serial << _F("Evaluating getValue ...") << endl;
 
-		// Cache store so it doesn't skew results
-		Serial << "INT:" << TestConfig::Root(database).getSimpleInt() << endl;
-		profile(F("getValue [int]"), [](unsigned) {
+		{
 			TestConfig::Root root(database);
-			root.getSimpleInt();
-		});
 
-		Serial << "FLOAT:" << TestConfig::Root(database).getSimpleFloat() << endl;
-		profile(F("getValue [float]"), [](unsigned) {
-			TestConfig::Root root(database);
-			root.getSimpleFloat();
-		});
+			// Cache store so it doesn't skew results
+			Serial << "INT:" << root.getSimpleInt() << endl;
+			profile(F("getValue [int]"), [&](unsigned) { root.getSimpleInt(); });
 
-		profile(F("getValue [Print]"), [](unsigned) {
-			MemoryDataStream stream;
-			TestConfig::Root root(database);
-			stream << root;
-		});
+			Serial << "FLOAT:" << root.getSimpleFloat() << endl;
+			profile(F("getValue [float]"), [&](unsigned) { root.getSimpleFloat(); });
+
+			profile(F("getValue [Print]"), [&](unsigned) {
+				MemoryDataStream stream;
+				stream << root;
+			});
+		}
 	}
 };
 

--- a/test/modules/Union.cpp
+++ b/test/modules/Union.cpp
@@ -22,7 +22,7 @@ public:
 	void execute() override
 	{
 		TestConfigUnion db(F("out/test-union"));
-		db.openStore(0, true)->clear();
+		db.openStoreForUpdate(0)->clear();
 		using Color = TestConfigUnion::ContainedColor;
 
 		TEST_CASE("Union")

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -17,9 +17,6 @@ public:
 
 	void execute() override
 	{
-		// TestConfigRef db("test-ref");
-		// TestConfigRef::Root root(db);
-
 		// Verify initial value
 		TestConfig::Root root(database);
 		Serial << root << endl;
@@ -61,7 +58,7 @@ public:
 		TEST_CASE("Int64")
 		{
 			TestConfigRange db(F("out/test-range"));
-			db.openStore(0, true)->clear();
+			db.openStoreForUpdate(0)->clear();
 			TestConfigRange::Root root(db);
 			REQUIRE_EQ(root.getInt64val(), -1);
 			if(auto update = root.update()) {


### PR DESCRIPTION
This PR fixes the issues raised in #29.

The performance tests have also been revised as setValue / getValue shouldn't include opening store.

**Add second cache for writes**

The database keeps a weak reference to all store instances used for updates. The main purpose for this is to determine whether a store is locked or not.

In addition, there is now a second write cache (a strong reference) so that subsequent updates don't have to reload from storage.


**Add `StoreRef` and `StoreUpdateRef` classes**

`StoreRef` inherits from `shared_ptr<Store>` and tracks both read and update use of a Store.
The destructor calls into the database so it can effectively decide when caches are no longer required and the memory can be freed.
Note that this has to take asynchronous updates into consideration.

A `StoreUpdateRef` inherits from `StoreRef` and handles reference-counting directly in its constructor/destructor/assignment operator.
This avoids calling `commit` in the Store destructor - there be dragons.


**openStore**

The `Database::openStore` method now just opens a store for reading. It returns a `StoreRef` instance.

To get an updatable store requires a second call to `Database::lockStore`. This returns a `StoreUpdateRef` instance. On failure, it returns a dummy instance which avoids dereferenced null pointers later on. The `bool` operator for this instance returns false.

The `openStoreForUpdate` is provided which does both operations together. One use-case for this is `database.openStoreForUpdate(0)->clear();` which is a one-liner to reset a store to defaults and commit it.

To summarise behaviour:

- Call OPEN to obtain read-only store
- Call LOCK to get updatable store. Operation results in either a COPY of an existing store, a LOAD from storage or FAIL.
- Can COPY where store is locked (in-use) but clean (not dirty), otherwise we need to LOAD a fresh copy from storage.
