### PR TITLE
Support export stream creation using JSONPath-like syntax

### DIFF
--- a/samples/Basic_Config/README.rst
+++ b/samples/Basic_Config/README.rst
@@ -26,6 +26,8 @@ Web client
 ----------
 
 The sample starts a basic HTTP server which can be visited to view the database content in JSON format.
+On the linux host emulator, for example, enter *http://192.168.13.10* to view the entire database.
+To view a specific object use JSONPath notation, for example *http://192.168.13.10/color.brightness*.
 
 An HTTP POST request can also be used to update the database contents.
 This must have `Content-Type: application/json` encoding.

--- a/samples/Basic_Config/app/application.cpp
+++ b/samples/Basic_Config/app/application.cpp
@@ -4,7 +4,6 @@
 #include <basic-config.h>
 #include <ConfigDB/Json/Format.h>
 #include <ConfigDB/Network/HttpImportResource.h>
-#include <Data/CStringArray.h>
 #include <Data/Format/Json.h>
 
 #ifdef ENABLE_MALLOC_COUNT
@@ -200,14 +199,14 @@ void printStoreStats(ConfigDB::Database& db, bool detailed)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	Serial << toString(request.method) << " REQ" << endl;
+	Serial << toString(request.method) << " \"" << request.uri.getRelativePath() << '"' << endl;
 
 	if(request.method != HTTP_GET) {
 		response.code = HTTP_STATUS_BAD_REQUEST;
 		return;
 	}
 
-	auto stream = database.createExportStream(ConfigDB::Json::format);
+	auto stream = database.createExportStream(ConfigDB::Json::format, request.uri.getRelativePath());
 	response.sendDataStream(stream.release(), MIME_JSON);
 }
 

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -110,11 +110,10 @@ public:
 
 	/**
 	 * @brief Create a read-only stream for serializing the database
+	 * @param format
+	 * @param path JSONPath-like expression to restrict output to specific store or object
 	 */
-	std::unique_ptr<ExportStream> createExportStream(const Format& format)
-	{
-		return format.createExportStream(*this);
-	}
+	std::unique_ptr<ExportStream> createExportStream(const Format& format, const String& path = nullptr);
 
 	/**
 	 * @brief Serialize the database to a stream


### PR DESCRIPTION
This PR extends the `Database::createExportStream` method to support basic path selection, for example `http://192.168.13.10/color.brightness`.

Array item selection isn't included, but could be added in a similar way for updates as discussed in #18.