### PR TITLE
Fix database streaming updates

### DIFF
--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -56,7 +56,7 @@ size_t ReadStream::fillStream(Print& p)
 	if(!printer.isDone()) {
 		return n;
 	}
-	store.reset();
+	store = {};
 
 	if(!db) {
 		done = true;

--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -24,13 +24,6 @@ using Element = JSON::Element;
 
 namespace ConfigDB::Json
 {
-WriteStream::~WriteStream()
-{
-	if(database && store) {
-		database->save(*store);
-	}
-}
-
 Status WriteStream::getStatus() const
 {
 	switch(jsonStatus) {
@@ -145,7 +138,7 @@ bool WriteStream::locateStoreOrRoot(const Element& element)
 	auto& root = database->typeinfo.stores[0];
 	int i = root.findObject(element.key, element.keyLength);
 	if(i >= 0) {
-		store.reset();
+		store = StoreUpdateRef();
 		store = database->openStoreForUpdate(0);
 		if(!store) {
 			return handleError(FormatError::UpdateConflict, element.getKey());
@@ -156,10 +149,7 @@ bool WriteStream::locateStoreOrRoot(const Element& element)
 	}
 
 	// Now check for a matching store
-	if(store) {
-		database->save(*store);
-	}
-	store.reset();
+	store = StoreUpdateRef();
 	i = database->typeinfo.findStore(element.key, element.keyLength);
 	if(i < 0) {
 		return handleError(FormatError::NotInSchema, element.getKey());

--- a/src/Json/WriteStream.h
+++ b/src/Json/WriteStream.h
@@ -46,8 +46,6 @@ public:
 	{
 	}
 
-	~WriteStream();
-
 	static Status parse(Database& database, Stream& source);
 
 	static Status parse(Object& object, Stream& source);

--- a/src/Json/WriteStream.h
+++ b/src/Json/WriteStream.h
@@ -99,6 +99,7 @@ private:
 		return true;
 	}
 
+	bool openStore(unsigned storeIndex);
 	bool locateStoreOrRoot(const JSON::Element& element);
 	bool handleSelector(const JSON::Element& element, const char* sel);
 	bool setProperty(const JSON::Element& element, Object& object, Property prop);

--- a/src/include/ConfigDB/StoreRef.h
+++ b/src/include/ConfigDB/StoreRef.h
@@ -37,6 +37,9 @@ public:
 	~StoreRef();
 
 	explicit operator bool() const;
+
+private:
+	using shared_ptr::reset;
 };
 
 class StoreUpdateRef : public StoreRef

--- a/test/modules/Sharing.cpp
+++ b/test/modules/Sharing.cpp
@@ -103,7 +103,7 @@ public:
 			update.intArray.addItem(12);
 			REQUIRE_EQ(root.intArray[0], 12);
 			update.intArray[0] = 123;
-			REQUIRE_EQ(root.intArray[0], 123);
+			REQUIRE_EQ(root.intArray[0], 100);
 			Serial << root.intArray << endl;
 		}
 		CHECK_EQ(ConfigDB::Store::getInstanceCount(), 2); // root, root2/root3

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -83,7 +83,7 @@ public:
 				const auto newFloat = 12.0e20;
 				Serial << newFloat << endl;
 				updater.setSimpleFloat(newFloat);
-				REQUIRE_EQ(String(root.getSimpleFloat()), F("1.2e21"));
+				REQUIRE_EQ(String(root.getSimpleFloat()), F("1.2e8"));
 			} else {
 				TEST_ASSERT(false);
 			}

--- a/test/resource/async-update-result.json
+++ b/test/resource/async-update-result.json
@@ -1,0 +1,1 @@
+{"int_array":[100,1],"string_array":["go","away"],"object_array":[{"intval":1,"stringval":"biscuit"},{"intval":2,"stringval":"cake"}],"color":"green","simple-bool":true,"simple-string":"gorilla","simple-int":100,"simple-float":1.2e8}

--- a/test/resource/async-update.json
+++ b/test/resource/async-update.json
@@ -1,0 +1,1 @@
+{"int_array":[127,1],"string_array":["go","away"],"object_array":[{"intval":1,"stringval":"biscuit"},{"intval":2,"stringval":"cake"}],"color":"green","simple-bool":true,"simple-string":"gorilla","simple-int":123,"simple-float":35e10}

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -27,12 +27,14 @@
     "simple-float": {
       "type": "number",
       "default": 3.141592654,
-      "maximum": 1.2e21
+      "maximum": 1.2e8
     },
     "int_array": {
       "type": "array",
       "items": {
-        "type": "integer"
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100
       },
       "default": [
         13,


### PR DESCRIPTION
Streaming database import doesn't work properly:

- Root store properties not handled
- Store locking problems. Cause is use of `reset` on `StoreUpdateRef`.
- No tests for database import. Add these and include both sync. and async. versions.