### PR TITLE
Support resetting properties to their default values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -414,8 +414,8 @@ For example:
 - Both of these classes provide *read-only* access to the data via `getXXX` methods.
 - Outer classes contain a :cpp:class:`ConfigDB::StoreRef`, whereas contained classes do not (they obtain the store from their parent object).
 - Application code can instantiate the *outer* class directly **BasicConfig::Network network(database);**
-- Child objects within classes are defined as member variables, such as **network.mqtt**, which is a **ContainedMqtt** class instance.
-- A third *updater* class type is also generated which adds *setXXX* methods for changing values.
+- Child objects within classes are defined as read-only member variables, such as **network.mqtt**, which is a **ContainedMqtt** class instance.
+- A third *updater* class type is also generated which adds *setXXX* and *resetXXX* methods for changing values. Child objects/arrays can be updated using their provided methods.
 - Only one *updater* per store can be open at a time. This ensures consistent data updates.
 
 

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -48,6 +48,8 @@ public:
 				// Check clipping
 				updater.setSimpleInt(101);
 				REQUIRE_EQ(root.getSimpleInt(), 100);
+				updater.resetSimpleInt();
+				REQUIRE_EQ(root.getSimpleInt(), -1);
 				updater.setSimpleInt(-6);
 				REQUIRE_EQ(root.getSimpleInt(), -5);
 			} else {
@@ -75,8 +77,9 @@ public:
 
 		TEST_CASE("Number")
 		{
+			DEFINE_FSTR_LOCAL(floatDefault, "3.1415927")
 			auto f = root.getSimpleFloat();
-			REQUIRE_EQ(String(f), "3.1415927");
+			REQUIRE_EQ(String(f), floatDefault);
 
 			// Change value
 			if(auto updater = root.update()) {
@@ -84,6 +87,8 @@ public:
 				Serial << newFloat << endl;
 				updater.setSimpleFloat(newFloat);
 				REQUIRE_EQ(String(root.getSimpleFloat()), F("1.2e8"));
+				updater.resetSimpleFloat();
+				REQUIRE_EQ(String(root.getSimpleFloat()), floatDefault);
 			} else {
 				TEST_ASSERT(false);
 			}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -1103,6 +1103,11 @@ def generate_property_write_accessors(obj: Object) -> list:
         f'void set{prop.typename}({get_ctype(prop)} value)',
         '{',
         [f'setPropertyValue({index}, {get_value_expr(prop)});'],
+        '}',
+        '',
+        f'void reset{prop.typename}()',
+        '{',
+        [f'setPropertyValue({index}, nullptr);'],
         '}'
         ) for index, prop in enumerate(obj.properties))]
 


### PR DESCRIPTION
Objects and arrays can be reset (PR #37) but as per https://github.com/mikee47/ConfigDB/discussions/20#discussioncomment-10471624 there is currently no specific way to reset property values to their default. This PR adds `resetXXXX()` methods to generated updater code for this purpose.

Objects have a defined `defaultData` structure which contains the default values and can be useful for introspection. These could be used to reset default values, but the types do not always agree with those in the API and doing it this way is a bit clunky.
