### PR TITLE
Fix handling of complex nested definitions

### DIFF
--- a/test/complex-nesting.cfgdb
+++ b/test/complex-nesting.cfgdb
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Schema with complex nested definitions, just check it compiles OK",
+  "type": "object",
+  "properties": {
+    "presets": {
+      "type": "object",
+      "store": true,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "color": {
+                "$ref": "#/$defs/Color"
+              },
+              "ts": {
+                "type": "integer"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "favorite": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    },
+    "controllers": {
+      "type": "object",
+      "store": true,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "ip": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "last-seen": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "scenes": {
+      "type": "object",
+      "store": true,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "settings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "controller_id": {
+                      "type": "integer"
+                    },
+                    "color": {
+                      "$ref": "#/$defs/Color"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "RAW": {
+      "type": "object",
+      "properties": {
+        "ww": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1023
+        },
+        "r": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1023
+        },
+        "b": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1023
+        },
+        "cw": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1023
+        },
+        "g": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1023
+        },
+        "nested-color": {
+          "$comment": "This is the 'complex nested definition'",
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "HSV": {
+      "type": "object",
+      "properties": {
+        "s": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "v": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "h": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 359
+        }
+      }
+    },
+    "Color": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/HSV"
+        },
+        {
+          "$ref": "#/$defs/RAW"
+        }
+      ]
+    },
+    "Channel": {
+      "type": "object",
+      "properties": {
+        "pin": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -1275,6 +1275,8 @@ def generate_contained_constructors(obj: Object, is_updater = False) -> list:
     if not obj.is_item_member:
         headers = [
             '',
+            f'{typename}() = default;',
+            '',
             f'{typename}(ConfigDB::Store& store, const ConfigDB::PropertyInfo& prop, uint16_t offset): ' + ', '.join([
                 f'{obj.base_class}{template}(store, prop, offset)',
                 *children

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -316,7 +316,7 @@ class Object:
         while obj:
             if not isinstance(obj, ObjectArray):
                 ns.insert(0, obj.typename_contained)
-            obj = obj.parent
+            obj = obj.database if obj.ref else obj.parent
         return '::'.join(ns)
 
     @property

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -565,7 +565,7 @@ def load_config(filename: str) -> Database:
             # Objects with 'store' annoation are managed by database, otherwise they live in root object
             if 'store' in fields:
                 if parent is not root:
-                    raise ValueError(f'{key} cannot have "store", not a root object')
+                    raise ValueError(f'{key} cannot have "store" annotation, not a root object')
                 obj = database
             else:
                 obj = parent
@@ -586,6 +586,9 @@ def load_config(filename: str) -> Database:
             database.object_defs[obj.typename] = obj
             parse_properties(obj, fields.get('properties', {}))
             return obj
+
+        if 'store' in fields:
+            raise ValueError(f'"{key}" cannot have "store" annotation, not an object')
 
         if prop_type == 'array':
             item_ref, items = resolve_ref(fields['items'], database)

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -1271,19 +1271,17 @@ def generate_contained_constructors(obj: Object, is_updater = False) -> list:
 
     typename = obj.typename_updater if is_updater else obj.typename_contained
     parent_typename = obj.parent.typename_updater if is_updater else obj.parent.typename_contained
-    headers = []
-    if not obj.is_item_member:
-        headers = [
-            '',
-            f'{typename}() = default;',
-            '',
-            f'{typename}(ConfigDB::Store& store, const ConfigDB::PropertyInfo& prop, uint16_t offset): ' + ', '.join([
-                f'{obj.base_class}{template}(store, prop, offset)',
-                *children
-            ]),
-            '{',
-            '}',
-        ]
+    headers = [
+        '',
+        f'{typename}() = default;',
+        '',
+        f'{typename}(ConfigDB::Object& parent, const ConfigDB::PropertyInfo& prop, uint16_t offset): ' + ', '.join([
+            f'{obj.base_class}{template}(parent, prop, offset)',
+            *children
+        ]),
+        '{',
+        '}',
+    ]
 
     if not obj.is_root:
         headers += [


### PR DESCRIPTION
This PR aims to resolve the issues raised in #50.

**Verify use of `store` annotation**

Must only be present on a root *object*. Code generator raises an exception if, for example, this annotation is found on an array.

**Fix type information namespace**

This is incorrectly generated for nested object definitions.

**Nested objects missing default constructors**

Required for exception conditions, such as accessing an invalid object type on a Union.

**Code generator confuses `is_store` and `is_root`**

`is_root` and `is_store` both return True for children of database.
This messes up global definitions.
Use a member variable for `is_store` and fix `is_root` implementation.

**Complex nested objects require `(object, prop, offset)` constructor**

This is required so a Union can return the embedded object type.