### PR TITLE
Fix definition-only schemas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ See the :sample:`Basic_Config` sample schema. The test application contains furt
 - A custom type can be defined for Property accessors using the **ctype** annotation. This means that with an IP address property, for example, you can use :cpp:class:`IpAddress` instead of :cpp:class:`String` because it can be constructed from a String. The database still stores the value internally as a regular String.
 - `Enumerated Properties`_ can be defined for any type; **ctype** is used here to optionally define a custom **enum class** type for these values.
 - Re-useable definitions can be created using the `$ref <https://json-schema.org/understanding-json-schema/structuring#dollarref>`__ schema keyword.
-  Such definitions must be contained within the **$defs** section of the schema.
+  Such definitions should be contained within the **$defs** section of the schema.
 - `Arrays`_ of simple types (including Strings) or objects are supported.
 - `Unions`_ can contain any one of a number of user-defined object types, and can be used in object arrays.
 - Null values are not supported. If encountered in existing datasets then ConfigDB uses the default value for the property.
@@ -199,9 +199,6 @@ The *dbgen.py* code generator is passed the names of *all* schema found in the c
   
     The full URI resolution described by JSON Schema is not currently implemented.
     This would require **$id** annotations in all schema.
-
-    Nested references are not supported. That is, a **$ref** must point to an actual definition and not just another **$ref**.
-
 
 When using shared objects only the name of the related property can be changed.
 For example::

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ See the :sample:`Basic_Config` sample schema. The test application contains furt
 - Null values are not supported. If encountered in existing datasets then ConfigDB uses the default value for the property.
 - Multiple property types, such as *"type": ["boolean", "null"]* are not supported. A type must be defined for all properties and must be a string value. This also applies to array items.
 
+.. highlight: json
 
 Aliases
 -------
@@ -123,8 +124,6 @@ at compile time.
 
 Enumerated properties
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. highlight: json
 
 JsonSchema offers the `enum <https://json-schema.org/understanding-json-schema/reference/enum>`__ keyword to restrict values to a set of known values. For example::
 
@@ -177,8 +176,6 @@ The code generator produces an **asXXX** method for each type of object which ca
 
 The corresponding Union Updater class has a :cpp:func:`ConfigDB::Union::setTag` method. This changes the stored object type and initialises it to default values. This is done even if the tag value doesn't change so can be used to 'reset' an object to defaults. The code generator produces a **toXXX** method which sets the tag and returns the appropriate object type.
 
-Option objects are specified using "$ref"
-
 
 Re-using objects
 ~~~~~~~~~~~~~~~~
@@ -207,7 +204,7 @@ The *dbgen.py* code generator is passed the names of *all* schema found in the c
 
 
 When using shared objects only the name of the related property can be changed.
-For example:
+For example::
 
   "font-color": {
     "foreground": {

--- a/test/test-config-defs-only.cfgdb
+++ b/test/test-config-defs-only.cfgdb
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "Color": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/RGB"
+        },
+        {
+          "$ref": "#/$defs/HSV"
+        },
+        {
+          "$ref": "#/$defs/RAW"
+        },
+        {
+          "$ref": "#/$defs/ColorList"
+        }
+      ]
+    },
+    "ColorList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Color"
+      }
+    },
+    "RGB": {
+      "type": "object",
+      "properties": {
+        "red": {
+          "$ref": "#/$defs/Color16",
+          "default": 100
+        },
+        "green": {
+          "$ref": "#/$defs/Color16",
+          "default": 100
+        },
+        "blue": {
+          "$ref": "#/$defs/Color16",
+          "default": 100
+        }
+      }
+    },
+    "HSV": {
+      "type": "object",
+      "properties": {
+        "hue": {
+          "$ref": "#/$defs/Degrees"
+        },
+        "saturation": {
+          "$ref": "#/$defs/Percent",
+          "default": 100
+        },
+        "value": {
+          "$ref": "#/$defs/Percent",
+          "default": 100
+        }
+      }
+    },
+    "RAW": {
+      "type": "object",
+      "properties": {
+        "red": {
+          "$ref": "#/$defs/Color16",
+          "default": 800
+        },
+        "green": {
+          "$ref": "#/$defs/Color16",
+          "default": 500
+        },
+        "blue": {
+          "$ref": "#/$defs/Color16",
+          "default": 200
+        },
+        "warm-white": {
+          "$ref": "#/$defs/Color16",
+          "default": 1023
+        },
+        "cold-white": {
+          "$ref": "#/$defs/Color16",
+          "default": 0
+        }
+      }
+    },
+    "Color16": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1023
+    },
+    "Degrees": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 359
+    },
+    "Percent": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "array-with-defaults": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "one",
+        "two",
+        "three",
+        "four"
+      ]
+    }
+  }
+}

--- a/test/test-external.cfgdb
+++ b/test/test-external.cfgdb
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "color": {
-      "$ref": "test-config-union/$defs/Color"
+      "$ref": "test-config-defs-only/$defs/Color"
     },
     "colors": {
       "$ref": "test-config-enum/properties/colors"

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -160,7 +160,11 @@ class Property:
         self.ctype = CPP_TYPENAMES[self.ptype]
         self.property_type = self.ptype.capitalize()
         self.alias = fields.get('alias')
-        self.is_store = ('store' in fields)
+        is_store = fields.get('store')
+        if is_store is not None:
+            self.is_store = True
+            if not isinstance(is_store, bool):
+                print(f'WARNING: bool expected for "{key}/properties/store", found "{is_store}"')
 
         if self.ptype == 'integer':
             int32 = IntRange(0, 0, True, 32)

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -676,7 +676,7 @@ def parse_database(database: Database):
     root = ObjectProperty(database, '', {}, Object('', None, database.schema_id))
     database.object_properties.append(root)
     root.is_store = True
-    parse_properties(root, database.schema['properties'])
+    parse_properties(root, database.schema.get('properties', {}))
 
 def generate_database(db: Database) -> CodeLines:
     '''Generate content for entire database'''

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -129,7 +129,12 @@ class IntRange(Range):
 
 def get_ptype(fields: dict):
     '''Identify a pseudo-type 'union' which makes script a bit clearer'''
-    return 'union' if 'oneOf' in fields else fields['type']
+    if 'oneOf' in fields:
+        return 'union'
+    ptype = fields.get('type')
+    if not ptype:
+        raise ValueError(f'"type" is required')
+    return ptype
 
 
 @dataclass
@@ -580,10 +585,7 @@ def load_schema(filename: str) -> Database:
 
 def parse_properties(path: str, parent_prop: Property, properties: dict):
     for key, fields in properties.items():
-        try:
-            parse_property(f'{path}/{key}', parent_prop, key, fields)
-        except Exception as e:
-            raise RuntimeError(f'"{path}/{key}"') from e
+        parse_property(f'{path}/{key}', parent_prop, key, fields)
 
 
 def parse_property(path: str, parent_prop: Property, key: str, fields: dict) -> Property:
@@ -603,119 +605,127 @@ def parse_property(path: str, parent_prop: Property, key: str, fields: dict) -> 
     We can put that definition directly into the schema so it only needs to be parsed once.
     No need for separate `Database.objects`, we use `Database.schema` instead.
     '''
-    database = parent_prop.database
-    schema_id = parent_prop.obj.schema_id or database.schema_id
+    try:
+        database = parent_prop.database
+        schema_id = parent_prop.obj.schema_id or database.schema_id
 
-    def create_object_property(obj: Object) -> Property:
-        # Objects with 'store' annoation are managed by database, otherwise they live in root object
-        if 'store' in fields:
-            if not parent_prop.is_root:
-                raise ValueError(f'{path} cannot have "store" annotation, not a root object')
-            prop = ObjectProperty(database, key, fields, obj)
-            prop.is_store = True
-            database.object_properties.append(prop)
+        def create_object_property(obj: Object) -> Property:
+            # Objects with 'store' annoation are managed by database, otherwise they live in root object
+            if 'store' in fields:
+                if not parent_prop.is_root:
+                    raise ValueError(f'{path} cannot have "store" annotation, not a root object')
+                prop = ObjectProperty(database, key, fields, obj)
+                prop.is_store = True
+                database.object_properties.append(prop)
+            else:
+                prop = ObjectProperty(parent_prop, key, fields, obj)
+                parent_prop.obj.object_properties.append(prop)
+            return prop
+
+        if object_ref := fields.get('$ref'):
+            while object_ref:
+                if object_ref.startswith('#/'):
+                    ref = object_ref[2:]
+                    object_ref = f'{schema_id}/{ref}'
+                else:
+                    schema_id, _, ref = object_ref.partition('/')
+                path = f'{path} -> /{object_ref}'
+                db = databases.get(schema_id)
+                if not db:
+                    raise ValueError(f'Database "{schema_id}" not found')
+                parent = db
+                ref_node = db.schema
+                while ref:
+                    if 'object' in ref_node:
+                        parent = ref_node['object']
+                    name, _, ref = ref.partition('/')
+                    ref_node = ref_node.get(name)
+                    if not ref_node:
+                        raise ValueError(f'Missing reference "{name}" in "{object_ref}"')
+                object_name = name
+                if not key:
+                    key = name
+
+                # Has object already been parsed?
+                if obj := ref_node.get('object'):
+                    if obj.schema_id != parent_prop.obj.schema_id:
+                        database.external_objects[object_ref] = obj
+                    return create_object_property(obj)
+
+                if next_ref := ref_node.get('$ref'):
+                    object_ref = next_ref
+                else:
+                    break
         else:
-            prop = ObjectProperty(parent_prop, key, fields, obj)
-            parent_prop.obj.object_properties.append(prop)
-        return prop
+            object_name = key
+            parent = parent_prop.obj
+            ref_node = None
 
-    if object_ref := fields.get('$ref'):
-        while object_ref:
-            if object_ref.startswith('#/'):
-                ref = object_ref[2:]
-                object_ref = f'{schema_id}/{ref}'
-            else:
-                schema_id, _, ref = object_ref.partition('/')
-            path = f'{path} -> /{object_ref}'
-            db = databases[schema_id]
-            parent = db
-            ref_node = db.schema
-            while ref:
-                if 'object' in ref_node:
-                    parent = ref_node['object']
-                name, _, ref = ref.partition('/')
-                ref_node = ref_node[name]
-            object_name = name
-            if not key:
-                key = name
+        prop_type = get_ptype(ref_node or fields)
 
-            # Has object already been parsed?
-            if obj := ref_node.get('object'):
-                if obj.schema_id != parent_prop.obj.schema_id:
-                    database.external_objects[object_ref] = obj
-                return create_object_property(obj)
+        if prop_type not in ['object', 'array', 'union']:
+            if ref_node:
+                # For simple properties the definition is a template, so copy over any non-existent values
+                for k, v in ref_node.items():
+                    if k not in fields:
+                        fields[k] = v
 
-            if next_ref := ref_node.get('$ref'):
-                object_ref = next_ref
-            else:
-                break
-    else:
-        object_name = key
-        parent = parent_prop.obj
-        ref_node = None
+            prop = Property(parent_prop, key, fields)
+            parent_prop.obj.properties.append(prop)
+            return prop
 
-    prop_type = get_ptype(ref_node or fields)
-
-    if CPP_TYPENAMES[prop_type] != '-':
         if ref_node:
-            # For simple properties the definition is a template, so copy over any non-existent values
-            for k, v in ref_node.items():
-                if k not in fields:
-                    fields[k] = v
+            fields = ref_node
 
-        prop = Property(parent_prop, key, fields)
-        parent_prop.obj.properties.append(prop)
-        return prop
+        def create_object_and_property(Class) -> Property:
+            obj = Class(database if 'store' in fields else db if object_ref else parent, object_name, object_ref, schema_id)
+            if object_ref:
+                db.object_defs[object_ref] = obj
+            if obj.schema_id != parent_prop.obj.schema_id:
+                database.external_objects[object_ref] = obj
+            fields['object'] = obj
+            return create_object_property(obj)
 
-    if ref_node:
-        fields = ref_node
-
-    def create_object_and_property(Class) -> Property:
-        obj = Class(database if 'store' in fields else db if object_ref else parent, object_name, object_ref, schema_id)
-        if object_ref:
-            db.object_defs[object_ref] = obj
-        if obj.schema_id != parent_prop.obj.schema_id:
-            database.external_objects[object_ref] = obj
-        fields['object'] = obj
-        return create_object_property(obj)
-
-    if prop_type == 'object':
-        if 'default' in fields:
-            raise ValueError('Object default not supported (use default on properties)')
-        object_prop = create_object_and_property(Object)
-        parse_properties(f'{path}/properties', object_prop, fields.get('properties', {}))
-        return object_prop
-
-    if prop_type == 'array':
-        items = fields['items']
-        array_prop = create_object_and_property(Array)
-        items_prop = parse_property(f'{path}/items', array_prop, f'{array_prop.typename}Item', items)
-        array_prop.obj.default = fields.get('default')
-        if array_prop.obj.is_object_array:
-            
+        if prop_type == 'object':
             if 'default' in fields:
-                raise ValueError('ObjectArray default not supported')
-        return array_prop
+                raise ValueError('Object default not supported (use default on properties)')
+            object_prop = create_object_and_property(Object)
+            parse_properties(f'{path}/properties', object_prop, fields.get('properties', {}))
+            return object_prop
 
-    if prop_type == 'union':
-        if 'default' in fields:
-            raise ValueError('Union default not supported')
-        union_prop = create_object_and_property(Union)
-        for i, opt in enumerate(fields['oneOf']):
-            prop = parse_property(f'{path}/oneOf/{i}', union_prop, opt.get('title'), opt)
-            if not prop.obj:
-                raise ValueError(f'Union "{union_prop.name}" option type must be *object*')
-            if not prop.id or not prop.obj.typename:
-                raise ValueError(f'Union "{union_prop.name}" option requires title or $ref')
-        prop = Property(union_prop, 'tag', {
-            'type': 'integer',
-            'minimum': 0,
-            'maximum': len(union_prop.obj.object_properties) - 1
-        })
-        union_prop.obj.properties.append(prop)
-        return union_prop
+        if prop_type == 'array':
+            items = fields.get('items')
+            if not items:
+                raise ValueError(f'Missing "items" property for array')
+            array_prop = create_object_and_property(Array)
+            items_prop = parse_property(f'{path}/items', array_prop, f'{array_prop.typename}Item', items)
+            array_prop.obj.default = fields.get('default')
+            if array_prop.obj.is_object_array:
+                if 'default' in fields:
+                    raise ValueError('ObjectArray default not supported')
+            return array_prop
 
-    raise ValueError('Bad type ' + prop_type)
+        if prop_type == 'union':
+            if 'default' in fields:
+                raise ValueError('Union default not supported')
+            union_prop = create_object_and_property(Union)
+            for i, opt in enumerate(fields['oneOf']):
+                prop = parse_property(f'{path}/oneOf/{i}', union_prop, opt.get('title'), opt)
+                if not prop.obj:
+                    raise ValueError(f'Union "{union_prop.name}" option type must be *object*')
+                if not prop.id or not prop.obj.typename:
+                    raise ValueError(f'Union "{union_prop.name}" option requires title or $ref')
+            prop = Property(union_prop, 'tag', {
+                'type': 'integer',
+                'minimum': 0,
+                'maximum': len(union_prop.obj.object_properties) - 1
+            })
+            union_prop.obj.properties.append(prop)
+            return union_prop
+
+        raise ValueError('Bad type ' + prop_type)
+    except ValueError as e:
+        raise RuntimeError(path) from e
 
 
 def parse_database(database: Database):
@@ -1455,4 +1465,10 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as e:
+        if e.__cause__:
+            print('ERROR:', e.__cause__, 'from', ', '.join(e.args))
+        else:
+            print(repr(e))


### PR DESCRIPTION
This PR addresses the concerns raised in issue #56:

- Definition-only schemas do not require a `properties` value
- `$ref` may be chained if required. That is, it can point directly to another `$ref`.
- Additional validation checks are made and the corresponding JSON Pointer path included in the message so the problem can be located.
- Class dependencies are handled better by pre-sorting definitions to avoid `invalid use of incomplete type` compiler errors.
