### PR TITLE
Add options for export streams

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -339,12 +339,12 @@ std::unique_ptr<ExportStream> Database::createExportStream(const Format& format,
 	return format.createExportStream(store, obj);
 }
 
-bool Database::exportToFile(const Format& format, const String& filename)
+bool Database::exportToFile(const Format& format, const String& filename, const ExportOptions& options)
 {
 	FileStream stream;
 	if(stream.open(filename, File::WriteOnly | File::CreateNewAlways)) {
 		StaticPrintBuffer<512> buffer(stream);
-		format.exportToStream(*this, buffer);
+		format.exportToStream(*this, buffer, options);
 	}
 
 	if(stream.getLastError() == FS_OK) {

--- a/src/Json/Format.cpp
+++ b/src/Json/Format.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const O
 
 size_t Format::exportToStream(const Object& object, Print& output) const
 {
-	Printer printer(output, object, pretty, Printer::RootStyle::braces);
+	Printer printer(output, object, pretty, RootStyle::braces);
 	size_t n{0};
 	do {
 		n += printer();

--- a/src/Json/Format.cpp
+++ b/src/Json/Format.cpp
@@ -28,17 +28,17 @@ Format format;
 
 std::unique_ptr<ExportStream> Format::createExportStream(Database& db) const
 {
-	return std::make_unique<ReadStream>(db, pretty);
+	return std::make_unique<ReadStream>(db);
 }
 
 std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const Object& object) const
 {
-	return std::make_unique<ReadStream>(store, object, pretty);
+	return std::make_unique<ReadStream>(store, object);
 }
 
-size_t Format::exportToStream(const Object& object, Print& output) const
+size_t Format::exportToStream(const Object& object, Print& output, const ExportOptions& options) const
 {
-	Printer printer(output, object, pretty, RootStyle::braces);
+	Printer printer(output, object, options.pretty, std::max(RootStyle::braces, options.rootStyle));
 	size_t n{0};
 	do {
 		n += printer();
@@ -46,9 +46,9 @@ size_t Format::exportToStream(const Object& object, Print& output) const
 	return n;
 }
 
-size_t Format::exportToStream(Database& database, Print& output) const
+size_t Format::exportToStream(Database& database, Print& output, const ExportOptions& options) const
 {
-	return ReadStream::print(database, output, pretty);
+	return ReadStream::print(database, output, options);
 }
 
 std::unique_ptr<ImportStream> Format::createImportStream(Database& db) const

--- a/src/Json/Printer.cpp
+++ b/src/Json/Printer.cpp
@@ -32,7 +32,7 @@ void Printer::setRootStyle(RootStyle style, const String& name)
 {
 	rootStyle = style;
 	switch(rootStyle) {
-	case RootStyle::hidden:
+	case RootStyle::content:
 		rootName = nullptr;
 		break;
 	case RootStyle::braces:

--- a/src/Json/Printer.h
+++ b/src/Json/Printer.h
@@ -30,18 +30,13 @@ namespace ConfigDB::Json
 class Printer
 {
 public:
-	/**
-	 * @brief Determines behaviour for display of initial object only (doesn't apply to children)
-	 */
-	enum class RootStyle {
-		hidden, ///< Don't show name or braces
-		braces, ///< Just show braces
-		normal, ///< Show name and braces
-	};
-
 	Printer() = default;
 
 	Printer(Print& p, const Object& object, bool pretty, RootStyle style);
+
+	void reset();
+
+	void setRootStyle(RootStyle style);
 
 	explicit operator bool() const
 	{
@@ -73,7 +68,7 @@ public:
 private:
 	Print* p{};
 	Object objects[JSON::StreamingParser::maxNesting];
-	const FlashString* rootName{};
+	RootStyle rootStyle{};
 	uint8_t nesting{};
 	bool pretty{};
 };

--- a/src/Json/Printer.h
+++ b/src/Json/Printer.h
@@ -36,7 +36,7 @@ public:
 
 	void reset();
 
-	void setRootStyle(RootStyle style);
+	void setRootStyle(RootStyle style, const String& name);
 
 	explicit operator bool() const
 	{
@@ -68,6 +68,7 @@ public:
 private:
 	Print* p{};
 	Object objects[JSON::StreamingParser::maxNesting];
+	String rootName;
 	RootStyle rootStyle{};
 	uint8_t nesting{};
 	bool pretty{};

--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -21,9 +21,9 @@
 
 namespace ConfigDB::Json
 {
-size_t ReadStream::print(Database& db, Print& p, bool pretty)
+size_t ReadStream::print(Database& db, Print& p, const ExportOptions& options)
 {
-	ReadStream rs(db, pretty);
+	ReadStream rs(db, options);
 	size_t n{0};
 	while(!rs.done) {
 		n += rs.fillStream(p);
@@ -45,7 +45,7 @@ size_t ReadStream::fillStream(Print& p)
 		}
 		store = db->openStore(storeIndex);
 		auto style = storeIndex == 0 ? RootStyle::content : RootStyle::name;
-		printer = Printer(p, *store, pretty, style);
+		printer = Printer(p, *store, options.pretty, style);
 	}
 
 	n += printer();

--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -44,7 +44,7 @@ size_t ReadStream::fillStream(Print& p)
 			n += p.print('{');
 		}
 		store = db->openStore(storeIndex);
-		auto style = storeIndex == 0 ? RootStyle::hidden : RootStyle::name;
+		auto style = storeIndex == 0 ? RootStyle::content : RootStyle::name;
 		printer = Printer(p, *store, pretty, style);
 	}
 

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -31,16 +31,17 @@ namespace ConfigDB::Json
 class ReadStream : public ExportStream
 {
 public:
-	ReadStream(Database& db, bool pretty) : db(&db), pretty(pretty)
+	ReadStream(Database& db, const ExportOptions& options = {}) : db(&db), options(options)
 	{
 	}
 
-	ReadStream(StoreRef& store, const Object& object, bool pretty)
-		: store(store), printer(stream, object, pretty, RootStyle::braces), pretty(pretty)
+	ReadStream(StoreRef& store, const Object& object, const ExportOptions& options = {})
+		: store(store), printer(stream, object, options.pretty, std::max(RootStyle::braces, options.rootStyle)),
+		  options(options)
 	{
 	}
 
-	static size_t print(Database& db, Print& p, bool pretty);
+	static size_t print(Database& db, Print& p, const ExportOptions& options);
 
 	bool isValid() const override
 	{
@@ -88,8 +89,8 @@ private:
 	StoreRef store;
 	Printer printer;
 	MemoryDataStream stream;
+	const ExportOptions options;
 	unsigned streamPos{0};
-	bool pretty;
 	uint8_t storeIndex{0};
 	bool done{false};
 };

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -36,7 +36,7 @@ public:
 	}
 
 	ReadStream(StoreRef& store, const Object& object, bool pretty)
-		: store(store), printer(stream, object, pretty, Printer::RootStyle::braces), pretty(pretty)
+		: store(store), printer(stream, object, pretty, RootStyle::braces), pretty(pretty)
 	{
 	}
 
@@ -49,7 +49,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	bool seek(int len) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	bool isFinished() override
 	{
@@ -71,6 +71,16 @@ public:
 		return Status{};
 	}
 
+	virtual Options getOptions() const override
+	{
+		return Options{};
+	}
+
+	virtual void setOptions(const Options& options) override
+	{
+		printer.setRootStyle(options.rootStyle);
+	}
+
 private:
 	size_t fillStream(Print& p);
 
@@ -78,6 +88,7 @@ private:
 	StoreRef store;
 	Printer printer;
 	MemoryDataStream stream;
+	unsigned streamPos{0};
 	bool pretty;
 	uint8_t storeIndex{0};
 	bool done{false};

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -78,7 +78,7 @@ public:
 
 	virtual void setOptions(const Options& options) override
 	{
-		printer.setRootStyle(options.rootStyle);
+		printer.setRootStyle(options.rootStyle, options.rootName);
 	}
 
 private:

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -415,18 +415,17 @@ PropertyConst Object::getProperty(unsigned index) const
 size_t Object::printTo(Print& p) const
 {
 	Json::Format format;
-	format.setPretty(true);
-	return format.exportToStream(*this, p);
+	return format.exportToStream(*this, p, {.pretty = true});
 }
 
-bool Object::exportToFile(const Format& format, const String& filename) const
+bool Object::exportToFile(const Format& format, const String& filename, const ExportOptions& options) const
 {
 	createDirectories(filename);
 
 	FileStream stream;
 	if(stream.open(filename, File::WriteOnly | File::CreateNewAlways)) {
 		StaticPrintBuffer<512> buffer(stream);
-		exportToStream(format, buffer);
+		exportToStream(format, buffer, options);
 	}
 
 	if(stream.getLastError() == FS_OK) {

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -118,15 +118,15 @@ public:
 	/**
 	 * @brief Serialize the database to a stream
 	 */
-	size_t exportToStream(const Format& format, Print& output)
+	size_t exportToStream(const Format& format, Print& output, const ExportOptions& options = {})
 	{
-		return format.exportToStream(*this, output);
+		return format.exportToStream(*this, output, options);
 	}
 
 	/**
 	 * @brief Serialize the database to a single file
 	 */
-	bool exportToFile(const Format& format, const String& filename);
+	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {});
 
 	/**
 	 * @brief De-serialize the entire database from a stream

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -36,7 +36,7 @@ public:
 };
 
 /**
- * @brief Options for streaming object output
+ * @brief Style options for output of root item in export stream
  */
 enum class RootStyle {
 	content, ///< Show content only 13,28,39,40
@@ -45,13 +45,36 @@ enum class RootStyle {
 	object,  ///< Add outer braces {"int_array":[13,28,39,40]}
 };
 
+/**
+ * @brief Options for streaming object output
+ */
+struct ExportOptions {
+	/**
+	 * @brief Applicable style for root object output
+	 */
+	RootStyle rootStyle{};
+
+	/**
+	 * @brief Optional override for root object name
+	 *
+	 * Useful where object is un-named or the name is to change.
+	 * Applicable to `name` and `object` root styles.
+	 */
+	String rootName;
+
+	/**
+	 * @brief Set compact (default) or prettified output.
+	 */
+	bool pretty{false};
+};
+
+/**
+ * @brief Interface for formatted export stream
+ */
 class ExportStream : public IDataSourceStream
 {
 public:
-	struct Options {
-		RootStyle rootStyle;
-		String rootName; ///< Optional override for root object name
-	};
+	using Options = ExportOptions;
 
 	virtual Status getStatus() const = 0;
 

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -113,15 +113,21 @@ public:
 
 	/**
 	 * @brief Print object
+	 * @param object The object to serialize
+	 * @param output Where to write output
+	 * @param options Advanced settings for adjusting output
 	 * @retval size_t Number of characters written
 	 */
-	virtual size_t exportToStream(const Object& object, Print& output) const = 0;
+	virtual size_t exportToStream(const Object& object, Print& output, const ExportOptions& options) const = 0;
 
 	/**
 	 * @brief Serialise entire database directly to an output stream
+	 * @param database The database to serialize
+	 * @param output Where to write output
+	 * @param options Advanced settings for adjusting output
 	 * @retval size_t Number of bytes written to the stream
 	 */
-	virtual size_t exportToStream(Database& database, Print& output) const = 0;
+	virtual size_t exportToStream(Database& database, Print& output, const ExportOptions& options) const = 0;
 
 	/**
 	 * @brief Create a stream for de-serialising (writing) into the database

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -35,10 +35,35 @@ public:
 	virtual Status getStatus() const = 0;
 };
 
+/**
+ * @brief Options for streaming object output
+ */
+enum class RootStyle {
+	hidden, ///< Show content only 13,28,39,40
+	braces, ///< Add braces [13,28,39,40]
+	name,   ///< Add name "int_array":[13,28,39,40]
+	object, ///< Add outer braces {"int_array":[13,28,39,40]}
+};
+
 class ExportStream : public IDataSourceStream
 {
 public:
+	struct Options {
+		RootStyle rootStyle;
+	};
+
 	virtual Status getStatus() const = 0;
+
+	/**
+	 * @brief Get currently active export options
+	 */
+	virtual Options getOptions() const = 0;
+
+	/**
+	 * @brief Set export options
+	 * @param options New options
+	 */
+	virtual void setOptions(const Options& options) = 0;
 };
 
 /**

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -39,10 +39,10 @@ public:
  * @brief Options for streaming object output
  */
 enum class RootStyle {
-	hidden, ///< Show content only 13,28,39,40
-	braces, ///< Add braces [13,28,39,40]
-	name,   ///< Add name "int_array":[13,28,39,40]
-	object, ///< Add outer braces {"int_array":[13,28,39,40]}
+	content, ///< Show content only 13,28,39,40
+	braces,  ///< Add braces [13,28,39,40]
+	name,	///< Add name "int_array":[13,28,39,40]
+	object,  ///< Add outer braces {"int_array":[13,28,39,40]}
 };
 
 class ExportStream : public IDataSourceStream

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -50,6 +50,7 @@ class ExportStream : public IDataSourceStream
 public:
 	struct Options {
 		RootStyle rootStyle;
+		String rootName; ///< Optional override for root object name
 	};
 
 	virtual Status getStatus() const = 0;

--- a/src/include/ConfigDB/Json/Format.h
+++ b/src/include/ConfigDB/Json/Format.h
@@ -33,8 +33,8 @@ public:
 
 	std::unique_ptr<ExportStream> createExportStream(Database& db) const override;
 	std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object) const override;
-	size_t exportToStream(const Object& object, Print& output) const override;
-	size_t exportToStream(Database& database, Print& output) const override;
+	size_t exportToStream(const Object& object, Print& output, const ExportOptions& options) const override;
+	size_t exportToStream(Database& database, Print& output, const ExportOptions& options) const override;
 	std::unique_ptr<ImportStream> createImportStream(Database& db) const override;
 	std::unique_ptr<ImportStream> createImportStream(StoreUpdateRef& store, Object& object) const override;
 	Status importFromStream(Object& object, Stream& source) const override;

--- a/src/include/ConfigDB/Json/Format.h
+++ b/src/include/ConfigDB/Json/Format.h
@@ -49,14 +49,6 @@ public:
 	{
 		return MimeType::JSON;
 	}
-
-	void setPretty(bool pretty)
-	{
-		this->pretty = pretty;
-	}
-
-private:
-	bool pretty{false};
 };
 
 extern Format format;

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -185,12 +185,12 @@ public:
 
 	size_t printTo(Print& p) const;
 
-	bool exportToStream(const Format& format, Print& output) const
+	bool exportToStream(const Format& format, Print& output, const ExportOptions& options = {}) const
 	{
-		return format.exportToStream(*this, output);
+		return format.exportToStream(*this, output, options);
 	}
 
-	bool exportToFile(const Format& format, const String& filename) const;
+	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {}) const;
 
 	Status importFromStream(const Format& format, Stream& source)
 	{

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -131,10 +131,10 @@ public:
 
 	using Object::exportToFile;
 
-	bool exportToFile(const Format& format) const
+	bool exportToFile(const Format& format, const ExportOptions& options = {}) const
 	{
 		String filename = getFilePath() + format.getFileExtension();
-		return exportToFile(format, filename);
+		return exportToFile(format, filename, options);
 	}
 
 	using Object::importFromFile;


### PR DESCRIPTION
This PR addresses issue #60 to enable variations in how JSON is generated.

An extensible `ExportStream::Options` structure has been added which can be manipulated via an export stream's `getOption` and `setOption` methods. This is cleaner than changing the method signatures for all `createExportStream` methods.

The *Streaming* test module demonstrates the effect of setting these options:

### Streaming object export options (intarray)

RootStyle::content `13,28,39,40`
RootStyle::braces `[13,28,39,40]`
RootStyle::name `"int_array":[13,28,39,40]`
RootStyle::object `{"int_array":[13,28,39,40]}`

With `rootName` override:

RootStyle::content `13,28,39,40`
RootStyle::braces `[13,28,39,40]`
RootStyle::name `"newname":[13,28,39,40]`
RootStyle::object `{"newname":[13,28,39,40]}`

### Streaming object export options (root)

RootStyle::content `"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927`
RootStyle::braces `{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}`
RootStyle::name `{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}`
RootStyle::object `{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}`
// With `rootName` override:
RootStyle::content `"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927`
RootStyle::braces `{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}`
RootStyle::name `"newname":{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}`
RootStyle::object `{"newname":{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}}`
```
