### PR TITLE
Fix handling of `name=value` selectors for root arrays

### DIFF
--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -85,8 +85,11 @@ bool WriteStream::startElement(const Element& element)
 
 	auto& parent = info[element.level - 1];
 
+	// Check for array selector expression
+	auto sel = strchr(element.key, '[');
+
 	if(database && element.level == 1) {
-		if(element.type == Element::Type::Object) {
+		if(!sel && element.type == Element::Type::Object) {
 			return locateStoreOrRoot(element);
 		}
 		// Assume this is a property of the root store
@@ -96,8 +99,6 @@ bool WriteStream::startElement(const Element& element)
 		parent = *store;
 	}
 
-	// Check for array selector expression
-	auto sel = strchr(element.key, '[');
 	if(sel) {
 		return handleSelector(element, sel);
 	}

--- a/test/include/ConfigDBTest.h
+++ b/test/include/ConfigDBTest.h
@@ -17,6 +17,14 @@ template <typename T> bool importObject(T& object, const String& data)
 	return bool(status);
 }
 
+inline bool importObject(ConfigDB::Database& db, const String& data)
+{
+	MemoryDataStream mem;
+	mem << data;
+	auto status = db.importFromStream(ConfigDB::Json::format, mem);
+	return bool(status);
+}
+
 template <typename T> String exportObject(T& object)
 {
 	MemoryDataStream mem;

--- a/test/modules/Streaming.cpp
+++ b/test/modules/Streaming.cpp
@@ -173,6 +173,26 @@ public:
 		{
 			arrayTests(object_array_test_cases, true);
 		}
+
+		TEST_CASE("Indexed object array update against database")
+		{
+			for(auto test : object_array_test_cases) {
+				String expr = test.expr.get(arrayTestData);
+				Serial << "CASE: " << expr << endl;
+				String result = test.result.get(arrayTestData);
+				bool isValid = (result[0] == '[');
+				Serial << expr << " -> ";
+				CHECK(importObject(database, json::array_test_default));
+				CHECK_EQ(importObject(database, expr), isValid);
+				if(isValid) {
+					TestConfig::Root root(database);
+					String s = exportObject(root.objectArray);
+					Serial << s;
+					REQUIRE_EQ(s, result);
+				}
+				Serial << " - " << result << endl;
+			}
+		}
 	}
 
 	void arrayTests(const FSTR::Array<ArrayTestCase>& testCases, bool isObject)


### PR DESCRIPTION
Using selector updates to object arrays in the root store fail. Fixes #63.

* [x] Find out why test case isn't failing. Answer: Only tests against `root` store itself. Requires additional tests.
* [x] Add tests for streaming updates against database