### PR TITLE
Support conversion of named selector into range

### DIFF
--- a/src/Json/WriteStream.cpp
+++ b/src/Json/WriteStream.cpp
@@ -236,7 +236,13 @@ bool WriteStream::handleSelector(const Element& element, const char* sel)
 			auto prop = item.getProperty(propIndex);
 			auto propValue = prop.getValue();
 			if(propValue.equals(value, valuelen)) {
-				obj = item;
+				if(element.type == Element::Type::Array) {
+					// Convert named selector into range
+					array.removeItem(i);
+					obj.streamPos = i; // Where to insert new items
+				} else {
+					obj = item;
+				}
 				return true;
 			}
 		}


### PR DESCRIPTION
As discussed in #63 there is currently no way to delete items using named selector syntax. This PR allows selectors such as `"{x[name=value]": []}` to delete items. This works by implicitly converting the selection into a range where the right-hand side contains an array expression.

* [ ] Work up test cases
* [ ] Update documentation