### PR TITLE
Add streaming export options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,24 @@ The :sample:`BasicConfig` sample demonstrates using the stream classes to read a
   Any invalid data in a JSON update file will produce a debug warning, but will not cause processing to stop.
   This behaviour can be changed by implementing a custom :cpp:func:`ConfigDB::Database::handleFormatError` method.
 
+Export
+  Methods are provided to export the entire database, or a specific store, object or array.
+  These can be divided into immediate methods such as :cpp:func:`ConfigDB::Database::exportToFile`,
+  which are appropriate for small amounts of data or local memory or file streams.
+
+  Methods such as :cpp:func:`ConfigDB::Database::createExportStream` create a read-only stream
+  instance which is necessary for large datasets and for passing data over network connections.
+  Data is serialised as it is read from the stream to minimise memory usage.
+
+  The generated output can be customised with an optional :cpp:struct:`ConfigDB::ExportOptions` parameter.
+
+Import
+  As with export, immediate methods such as :cpp:func:`ConfigDB::Database::importFromFile`
+  are available, plus streaming methods such as :cpp:func:`ConfigDB::Database::createImportStream`.
+
+Note that both import and export use the *content* of the object and do not include the name of the object itself.
+As a convenience, this behaviour can be changed via options, but only for export.
+
 
 JSON Update mechanism
 ---------------------

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -299,7 +299,8 @@ bool Database::save(Store& store) const
 	return result;
 }
 
-std::unique_ptr<ExportStream> Database::createExportStream(const Format& format, const String& path)
+std::unique_ptr<ExportStream> Database::createExportStream(const Format& format, const String& path,
+														   const ExportOptions& options)
 {
 	CStringArray csa;
 	{
@@ -309,7 +310,7 @@ std::unique_ptr<ExportStream> Database::createExportStream(const Format& format,
 	}
 	auto it = csa.begin();
 	if(!it) {
-		return format.createExportStream(*this);
+		return format.createExportStream(*this, options);
 	}
 
 	int storeIndex = typeinfo.findStore(*it, strlen(*it));
@@ -336,15 +337,15 @@ std::unique_ptr<ExportStream> Database::createExportStream(const Format& format,
 	}
 
 	Object obj(*store, *prop, offset);
-	return format.createExportStream(store, obj);
+	return format.createExportStream(store, obj, options);
 }
 
-bool Database::exportToFile(const Format& format, const String& filename)
+bool Database::exportToFile(const Format& format, const String& filename, const ExportOptions& options)
 {
 	FileStream stream;
 	if(stream.open(filename, File::WriteOnly | File::CreateNewAlways)) {
 		StaticPrintBuffer<512> buffer(stream);
-		format.exportToStream(*this, buffer);
+		format.exportToStream(*this, buffer, options);
 	}
 
 	if(stream.getLastError() == FS_OK) {

--- a/src/Json/Format.cpp
+++ b/src/Json/Format.cpp
@@ -26,19 +26,20 @@ namespace ConfigDB::Json
 {
 Format format;
 
-std::unique_ptr<ExportStream> Format::createExportStream(Database& db) const
+std::unique_ptr<ExportStream> Format::createExportStream(Database& db, const ExportOptions& options) const
 {
-	return std::make_unique<ReadStream>(db, pretty);
+	return std::make_unique<ReadStream>(db, options);
 }
 
-std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const Object& object) const
+std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const Object& object,
+														 const ExportOptions& options) const
 {
-	return std::make_unique<ReadStream>(store, object, pretty);
+	return std::make_unique<ReadStream>(store, object, options);
 }
 
-size_t Format::exportToStream(const Object& object, Print& output) const
+size_t Format::exportToStream(const Object& object, Print& output, const ExportOptions& options) const
 {
-	Printer printer(output, object, pretty, Printer::RootStyle::braces);
+	Printer printer(output, object, options.pretty, Printer::RootStyle::braces);
 	size_t n{0};
 	do {
 		n += printer();
@@ -46,9 +47,9 @@ size_t Format::exportToStream(const Object& object, Print& output) const
 	return n;
 }
 
-size_t Format::exportToStream(Database& database, Print& output) const
+size_t Format::exportToStream(Database& database, Print& output, const ExportOptions& options) const
 {
-	return ReadStream::print(database, output, pretty);
+	return ReadStream::print(database, output, options);
 }
 
 std::unique_ptr<ImportStream> Format::createImportStream(Database& db) const

--- a/src/Json/Format.cpp
+++ b/src/Json/Format.cpp
@@ -39,7 +39,9 @@ std::unique_ptr<ExportStream> Format::createExportStream(StoreRef store, const O
 
 size_t Format::exportToStream(const Object& object, Print& output, const ExportOptions& options) const
 {
-	Printer printer(output, object, options.pretty, Printer::RootStyle::braces);
+	Printer printer(output, object, options.pretty,
+					options.asObject ? Printer::RootStyle::object
+									 : options.useName ? Printer::RootStyle::name : Printer::RootStyle::braces);
 	size_t n{0};
 	do {
 		n += printer();

--- a/src/Json/Printer.h
+++ b/src/Json/Printer.h
@@ -34,9 +34,10 @@ public:
 	 * @brief Determines behaviour for display of initial object only (doesn't apply to children)
 	 */
 	enum class RootStyle {
-		hidden, ///< Don't show name or braces
-		braces, ///< Just show braces
-		normal, ///< Show name and braces
+		hidden, ///< Show content only 13,28,39,40
+		braces, ///< Add braces [13,28,39,40]
+		name,   ///< Add name "int_array":[13,28,39,40]
+		object, ///< Add outer braces {"int_array":[13,28,39,40]}
 	};
 
 	Printer() = default;
@@ -73,7 +74,7 @@ public:
 private:
 	Print* p{};
 	Object objects[JSON::StreamingParser::maxNesting];
-	const FlashString* rootName{};
+	RootStyle rootStyle{};
 	uint8_t nesting{};
 	bool pretty{};
 };

--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -21,9 +21,9 @@
 
 namespace ConfigDB::Json
 {
-size_t ReadStream::print(Database& db, Print& p, bool pretty)
+size_t ReadStream::print(Database& db, Print& p, const ExportOptions& options)
 {
-	ReadStream rs(db, pretty);
+	ReadStream rs(db, options);
 	size_t n{0};
 	while(!rs.done) {
 		n += rs.fillStream(p);
@@ -45,7 +45,7 @@ size_t ReadStream::fillStream(Print& p)
 		}
 		store = db->openStore(storeIndex);
 		auto style = storeIndex == 0 ? Printer::RootStyle::hidden : Printer::RootStyle::normal;
-		printer = Printer(p, *store, pretty, style);
+		printer = Printer(p, *store, options.pretty, style);
 	}
 
 	n += printer();

--- a/src/Json/ReadStream.cpp
+++ b/src/Json/ReadStream.cpp
@@ -18,6 +18,7 @@
  ****/
 
 #include "ReadStream.h"
+#include "Data/Format/Json.h"
 
 namespace ConfigDB::Json
 {
@@ -41,10 +42,19 @@ size_t ReadStream::fillStream(Print& p)
 
 	if(db && !store) {
 		if(storeIndex == 0) {
+			if(options.asObject) {
+				n += p.print('{');
+			}
+			if(options.useName || options.asObject) {
+				String s = db->typeinfo.name;
+				::Format::json.quote(s);
+				n += p.print(s);
+				n += p.print(':');
+			}
 			n += p.print('{');
 		}
 		store = db->openStore(storeIndex);
-		auto style = storeIndex == 0 ? Printer::RootStyle::hidden : Printer::RootStyle::normal;
+		auto style = storeIndex == 0 ? Printer::RootStyle::hidden : Printer::RootStyle::name;
 		printer = Printer(p, *store, options.pretty, style);
 	}
 
@@ -69,6 +79,9 @@ size_t ReadStream::fillStream(Print& p)
 	n += printer.newline();
 	n += p.print('}');
 	n += printer.newline();
+	if(options.asObject) {
+		n += p.print('}');
+	}
 	done = true;
 	return n;
 }

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -36,7 +36,11 @@ public:
 	}
 
 	ReadStream(StoreRef& store, const Object& object, const ExportOptions& options = {})
-		: store(store), printer(stream, object, options.pretty, Printer::RootStyle::braces), options(options)
+		: store(store),
+		  printer(stream, object, options.pretty,
+				  options.asObject ? Printer::RootStyle::object
+								   : options.useName ? Printer::RootStyle::name : Printer::RootStyle::braces),
+		  options(options)
 	{
 	}
 

--- a/src/Json/ReadStream.h
+++ b/src/Json/ReadStream.h
@@ -31,16 +31,16 @@ namespace ConfigDB::Json
 class ReadStream : public ExportStream
 {
 public:
-	ReadStream(Database& db, bool pretty) : db(&db), pretty(pretty)
+	ReadStream(Database& db, const ExportOptions& options = {}) : db(&db), options(options)
 	{
 	}
 
-	ReadStream(StoreRef& store, const Object& object, bool pretty)
-		: store(store), printer(stream, object, pretty, Printer::RootStyle::braces), pretty(pretty)
+	ReadStream(StoreRef& store, const Object& object, const ExportOptions& options = {})
+		: store(store), printer(stream, object, options.pretty, Printer::RootStyle::braces), options(options)
 	{
 	}
 
-	static size_t print(Database& db, Print& p, bool pretty);
+	static size_t print(Database& db, Print& p, const ExportOptions& options);
 
 	bool isValid() const override
 	{
@@ -78,7 +78,7 @@ private:
 	StoreRef store;
 	Printer printer;
 	MemoryDataStream stream;
-	bool pretty;
+	const ExportOptions options;
 	uint8_t storeIndex{0};
 	bool done{false};
 };

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -415,18 +415,17 @@ PropertyConst Object::getProperty(unsigned index) const
 size_t Object::printTo(Print& p) const
 {
 	Json::Format format;
-	format.setPretty(true);
-	return format.exportToStream(*this, p);
+	return format.exportToStream(*this, p, {.pretty = true});
 }
 
-bool Object::exportToFile(const Format& format, const String& filename) const
+bool Object::exportToFile(const Format& format, const String& filename, const ExportOptions& options) const
 {
 	createDirectories(filename);
 
 	FileStream stream;
 	if(stream.open(filename, File::WriteOnly | File::CreateNewAlways)) {
 		StaticPrintBuffer<512> buffer(stream);
-		exportToStream(format, buffer);
+		exportToStream(format, buffer, options);
 	}
 
 	if(stream.getLastError() == FS_OK) {

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -110,14 +110,18 @@ public:
 
 	/**
 	 * @brief Create a read-only stream for serializing the database
-	 * @param format
+	 * @param format Formatter used to generate output
 	 * @param path JSONPath-like expression to restrict output to specific store or object
+	 * @param options Options for customising output
 	 */
 	std::unique_ptr<ExportStream> createExportStream(const Format& format, const String& path = nullptr,
 													 const ExportOptions& options = {});
 
 	/**
 	 * @brief Serialize the database to a stream
+	 * @param format Formatter used to generate output
+	 * @param output Where to write output
+	 * @param options Options for customising output
 	 */
 	size_t exportToStream(const Format& format, Print& output, const ExportOptions& options = {})
 	{
@@ -126,11 +130,16 @@ public:
 
 	/**
 	 * @brief Serialize the database to a single file
+	 * @param format Formatter used to generate output
+	 * @param filename Where to write output. Non-existent directories are created automatically.
+	 * @param options Options for customising output
 	 */
 	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {});
 
 	/**
 	 * @brief De-serialize the entire database from a stream
+	 * @param format Formatter used to read the source data
+	 * @param source The source data
 	 */
 	Status importFromStream(const Format& format, Stream& source)
 	{
@@ -139,11 +148,14 @@ public:
 
 	/**
 	 * @brief De-serialize the entire database from a file
+	 * @param format Formatter used to read the source data
+	 * @param filename File containing source data
 	 */
 	Status importFromFile(const Format& format, const String& filename);
 
 	/**
 	 * @brief Create a write-only stream for de-serializing the database
+	 * @param format Formatter used to process incoming data from the stream
 	 */
 	std::unique_ptr<ImportStream> createImportStream(const Format& format)
 	{

--- a/src/include/ConfigDB/Database.h
+++ b/src/include/ConfigDB/Database.h
@@ -113,20 +113,21 @@ public:
 	 * @param format
 	 * @param path JSONPath-like expression to restrict output to specific store or object
 	 */
-	std::unique_ptr<ExportStream> createExportStream(const Format& format, const String& path = nullptr);
+	std::unique_ptr<ExportStream> createExportStream(const Format& format, const String& path = nullptr,
+													 const ExportOptions& options = {});
 
 	/**
 	 * @brief Serialize the database to a stream
 	 */
-	size_t exportToStream(const Format& format, Print& output)
+	size_t exportToStream(const Format& format, Print& output, const ExportOptions& options = {})
 	{
-		return format.exportToStream(*this, output);
+		return format.exportToStream(*this, output, options);
 	}
 
 	/**
 	 * @brief Serialize the database to a single file
 	 */
-	bool exportToFile(const Format& format, const String& filename);
+	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {});
 
 	/**
 	 * @brief De-serialize the entire database from a stream

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -40,6 +40,18 @@ public:
  */
 struct ExportOptions {
 	/**
+	 * @brief Include the object name in output.
+	 */
+	bool useName{false};
+
+	/**
+	 * @brief Wrap everything as an object definition
+	 *
+	 * For JSON, this adds outer braces.
+	 */
+	bool asObject{false};
+
+	/**
 	 * @brief Set compact (default) or prettified output.
 	 */
 	bool pretty{false};

--- a/src/include/ConfigDB/Format.h
+++ b/src/include/ConfigDB/Format.h
@@ -35,6 +35,19 @@ public:
 	virtual Status getStatus() const = 0;
 };
 
+/**
+ * @brief Options for streaming object output
+ */
+struct ExportOptions {
+	/**
+	 * @brief Set compact (default) or prettified output.
+	 */
+	bool pretty{false};
+};
+
+/**
+ * @brief Interface for formatted export stream
+ */
 class ExportStream : public IDataSourceStream
 {
 public:
@@ -49,30 +62,41 @@ class Format
 public:
 	/**
 	 * @brief Create a stream to serialize the entire database
+	 * @param database The database to serialize
+	 * @param options Advanced settings for adjusting output
+	 *
 	 * This is used for streaming asychronously to a web client, for example in an HttpResponse.
 	 */
-	virtual std::unique_ptr<ExportStream> createExportStream(Database& db) const = 0;
+	virtual std::unique_ptr<ExportStream> createExportStream(Database& db, const ExportOptions& options = {}) const = 0;
 
 	/**
 	 * @brief Create a stream to serialize an Object
 	 * @param store Shared pointer to store
 	 * @param object Object to start streaming from
+	 * @param options Advanced settings for adjusting output
 	 *
 	 * Used for streaming asychronously to a web client, for example in an HttpResponse.
 	 */
-	virtual std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object) const = 0;
+	virtual std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object,
+															 const ExportOptions& options = {}) const = 0;
 
 	/**
 	 * @brief Print object
+	 * @param object The object to serialize
+	 * @param output Where to write output
+	 * @param options Advanced settings for adjusting output
 	 * @retval size_t Number of characters written
 	 */
-	virtual size_t exportToStream(const Object& object, Print& output) const = 0;
+	virtual size_t exportToStream(const Object& object, Print& output, const ExportOptions& options = {}) const = 0;
 
 	/**
 	 * @brief Serialise entire database directly to an output stream
+	 * @param database The database to serialize
+	 * @param output Where to write output
+	 * @param options Advanced settings for adjusting output
 	 * @retval size_t Number of bytes written to the stream
 	 */
-	virtual size_t exportToStream(Database& database, Print& output) const = 0;
+	virtual size_t exportToStream(Database& database, Print& output, const ExportOptions& options = {}) const = 0;
 
 	/**
 	 * @brief Create a stream for de-serialising (writing) into the database

--- a/src/include/ConfigDB/Json/Format.h
+++ b/src/include/ConfigDB/Json/Format.h
@@ -31,10 +31,11 @@ class Format : public ConfigDB::Format
 public:
 	DEFINE_FSTR_LOCAL(fileExtension, ".json")
 
-	std::unique_ptr<ExportStream> createExportStream(Database& db) const override;
-	std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object) const override;
-	size_t exportToStream(const Object& object, Print& output) const override;
-	size_t exportToStream(Database& database, Print& output) const override;
+	std::unique_ptr<ExportStream> createExportStream(Database& db, const ExportOptions& options) const override;
+	std::unique_ptr<ExportStream> createExportStream(StoreRef store, const Object& object,
+													 const ExportOptions& options) const override;
+	size_t exportToStream(const Object& object, Print& output, const ExportOptions& options) const override;
+	size_t exportToStream(Database& database, Print& output, const ExportOptions& options) const override;
 	std::unique_ptr<ImportStream> createImportStream(Database& db) const override;
 	std::unique_ptr<ImportStream> createImportStream(StoreUpdateRef& store, Object& object) const override;
 	Status importFromStream(Object& object, Stream& source) const override;
@@ -49,14 +50,6 @@ public:
 	{
 		return MimeType::JSON;
 	}
-
-	void setPretty(bool pretty)
-	{
-		this->pretty = pretty;
-	}
-
-private:
-	bool pretty{false};
 };
 
 extern Format format;

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -185,12 +185,12 @@ public:
 
 	size_t printTo(Print& p) const;
 
-	bool exportToStream(const Format& format, Print& output) const
+	bool exportToStream(const Format& format, Print& output, const ExportOptions& options = {}) const
 	{
-		return format.exportToStream(*this, output);
+		return format.exportToStream(*this, output, options);
 	}
 
-	bool exportToFile(const Format& format, const String& filename) const;
+	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {}) const;
 
 	Status importFromStream(const Format& format, Stream& source)
 	{
@@ -366,9 +366,9 @@ public:
 	{
 	}
 
-	std::unique_ptr<ExportStream> createExportStream(const Format& format) const
+	std::unique_ptr<ExportStream> createExportStream(const Format& format, const ExportOptions& options = {}) const
 	{
-		return format.createExportStream(store, *this);
+		return format.createExportStream(store, *this, options);
 	}
 
 	using OuterUpdater =

--- a/src/include/ConfigDB/Object.h
+++ b/src/include/ConfigDB/Object.h
@@ -183,20 +183,45 @@ public:
 
 	String getPath() const;
 
+	/**
+	 * @brief Support standard streaming output of this object's content in prettified JSON.
+	 */
 	size_t printTo(Print& p) const;
 
+	/**
+	 * @brief Export object to an output stream
+	 * @param format Formatter used to generate output
+	 * @param output Where to write output
+	 * @param options Options for customising output
+	 */
 	bool exportToStream(const Format& format, Print& output, const ExportOptions& options = {}) const
 	{
 		return format.exportToStream(*this, output, options);
 	}
 
+	/**
+	 * @brief Export object to an output stream
+	 * @param format Formatter used to generate output
+	 * @param filename Where to write output. Non-existent directories are created automatically.
+	 * @param options Options for customising output
+	 */
 	bool exportToFile(const Format& format, const String& filename, const ExportOptions& options = {}) const;
 
+	/**
+	 * @brief Import content to this object
+	 * @param format Formatter used to read the source data
+	 * @param source The source data, not including the name of the object itself
+	 */
 	Status importFromStream(const Format& format, Stream& source)
 	{
 		return format.importFromStream(*this, source);
 	}
 
+	/**
+	 * @brief Import content to this object
+	 * @param format Formatter used to read the source data
+	 * @param filename File containing source data, not including the name of the object itself
+	 */
 	Status importFromFile(const Format& format, const String& filename);
 
 	const PropertyInfo& propinfo() const
@@ -328,6 +353,10 @@ public:
 	{
 	}
 
+	/**
+	 * @brief Create a write-only stream for importing data to this object
+	 * @param format Format of the incoming data
+	 */
 	std::unique_ptr<ImportStream> createImportStream(const Format& format)
 	{
 		return format.createImportStream(store, *this);
@@ -366,6 +395,12 @@ public:
 	{
 	}
 
+	/**
+	 * @brief Create a read-only stream for serializing object contents
+	 * @param format Formatter used to generate output
+	 * @param path JSONPath-like expression to restrict output to specific store or object
+	 * @param options Options for customising output
+	 */
 	std::unique_ptr<ExportStream> createExportStream(const Format& format, const ExportOptions& options = {}) const
 	{
 		return format.createExportStream(store, *this, options);

--- a/src/include/ConfigDB/Store.h
+++ b/src/include/ConfigDB/Store.h
@@ -131,10 +131,10 @@ public:
 
 	using Object::exportToFile;
 
-	bool exportToFile(const Format& format) const
+	bool exportToFile(const Format& format, const ExportOptions& options = {}) const
 	{
 		String filename = getFilePath() + format.getFileExtension();
-		return exportToFile(format, filename);
+		return exportToFile(format, filename, options);
 	}
 
 	using Object::importFromFile;


### PR DESCRIPTION
This PR addresses issue #60 to enable variations in how JSON is generated.

An extensible `ExportOptions` structure has been added to all `createExportStream` and `exportToStream` methods to allow customisation of output. It contains three flags:

**pretty**

This replaces the global `Json::format.pretty` flag to allow control on a per-stream basis.

**useName**

Set this flag to include the object name in the output. For example:

```json
"int_array": [13,28,39,40]
```

Default behaviour excludes the name:

```json
[13,28,39,40]
```

This also works for the database using the name defined in the schema.

**asObject**

Outputs the entire object definition:

```json
{
  "int_array": [13,28,39,40]
}
```

The `useName` flag is implicit in this option and does not need to be set as well.

NB. I decided against using an enum to try and simplify the interface.

* [ ] Update README
