### PR TITLE
Fix bug where unable to change default on enum properties

### DIFF
--- a/test/test-config-enum.cfgdb
+++ b/test/test-config-enum.cfgdb
@@ -3,7 +3,8 @@
   "type": "object",
   "properties": {
     "color": {
-      "$ref": "#/$defs/Color"
+      "$ref": "#/$defs/Color",
+      "default": "green"
     },
     "colors": {
       "type": "array",

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -238,8 +238,6 @@ class Property:
                 self.validate_type(x, attr_name)
             return
         if self.enum:
-            if value not in self.enum and value != 0:
-                raise ValueError(f'Attribute "{attr_name}" ({value}) not in enum')
             return
         types = {
             'array': list,


### PR DESCRIPTION
fixed a bug in dbgen.py, where a default value was checked against an enum after the value had been converted to an index into the enum as documented in #70 

I feel that the 2nd check is redundant as the default has already been verified against the enum and the index was successfully calulated, therefore I believe it can be just removed.