### PR TITLE
Fix enum typedefs

### DIFF
--- a/test/modules/Enum.cpp
+++ b/test/modules/Enum.cpp
@@ -19,10 +19,10 @@ public:
 
 		using Root = TestConfigEnum::Root;
 
-		auto& colorType = Root::Colors::itemtype;
-		auto& quotientType = Root::Quotients::itemtype;
-		auto& smallMapType = Root::SmallMap::itemtype;
-		auto& numberMapType = Root::NumberMap::itemtype;
+		auto& colorType = Root::Colors::itemType;
+		auto& quotientType = Root::Quotients::itemType;
+		auto& smallMapType = Root::SmallMap::itemType;
+		auto& numberMapType = Root::NumberMap::itemType;
 
 		Serial << "colors[" << colorType.values().length() << "]: " << colorType.values() << endl;
 		Serial << "quotients[" << quotientType.values().length() << "]: " << quotientType.values() << endl;

--- a/test/test-config-enum.cfgdb
+++ b/test/test-config-enum.cfgdb
@@ -3,8 +3,30 @@
   "type": "object",
   "properties": {
     "color": {
-      "$ref": "#/$defs/Color",
-      "default": "green"
+      "$ref": "#/$defs/Color"
+    },
+    "num": {
+      "type": "integer",
+      "default": 25,
+      "enum": [
+        15,
+        37,
+        1445,
+        889,
+        25,
+        45,
+        18
+      ]
+    },
+    "word": {
+      "type": "string",
+      "default": "brown",
+      "enum": [
+        "the",
+        "quick",
+        "brown",
+        "fox"
+      ]
     },
     "colors": {
       "type": "array",

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -978,7 +978,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
 
     obj = object_prop.obj
 
-       def getVariantInfo(prop: Property) -> list:
+    def getVariantInfo(prop: Property) -> list:
         if prop.enum:
             values = prop.enum
             obj_type = f'{object_prop.namespace}::{obj.typename_contained}'
@@ -1046,6 +1046,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
 
     proplist = []
     aliaslist = [] 
+
     def add_alias(alias: str | list):
         if alias is None:
             return

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -988,8 +988,10 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
                     '',
                     f'using Item = {prop.ctype_override};'
                 ]
-            itemtype_name = f'{make_typename(prop.name)}ItemType'
-            itemtype_var = f'{prop.id}ItemType'
+            # Objects can contain multiple enums so use unique names,
+            # but make an exception for array items since there is only one definition
+            itemtype_name = 'ItemType' if prop.is_item else f'{make_typename(prop.name)}Type'
+            itemtype_var = 'itemType' if prop.is_item else f'{prop.id}Type'
             lines.header += [
                 '',
                 f'struct {itemtype_name} {{',
@@ -1012,7 +1014,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
                 ],
                 '};',
                 '',
-                f'static const {itemtype_name} {prop.id}ItemType;',
+                f'static const {itemtype_name} {itemtype_var};',
             ]
             lines.source += [
                 '',
@@ -1045,7 +1047,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
         return ''
 
     proplist = []
-    aliaslist = [] 
+    aliaslist = []
 
     def add_alias(alias: str | list):
         if alias is None:

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -978,7 +978,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
 
     obj = object_prop.obj
 
-    def getVariantInfo(prop: Property) -> list:
+       def getVariantInfo(prop: Property) -> list:
         if prop.enum:
             values = prop.enum
             obj_type = f'{object_prop.namespace}::{obj.typename_contained}'
@@ -988,9 +988,11 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
                     '',
                     f'using Item = {prop.ctype_override};'
                 ]
+            itemtype_name = f'{make_typename(prop.name)}ItemType'
+            itemtype_var = f'{prop.id}ItemType'
             lines.header += [
                 '',
-                'struct ItemType {',
+                f'struct {itemtype_name} {{',
                 [
                     'ConfigDB::EnumInfo enuminfo;',
                     f'{item_type} data[{len(values)}];',
@@ -1010,11 +1012,11 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
                 ],
                 '};',
                 '',
-                'static const ItemType itemtype;',
+                f'static const {itemtype_name} {prop.id}ItemType;',
             ]
             lines.source += [
                 '',
-                f'constexpr const {obj_type}::ItemType {obj_type}::itemtype PROGMEM = {{',
+                f'constexpr const {obj_type}::{itemtype_name} {obj_type}::{itemtype_var} PROGMEM = {{',
                 [
                     f'{{PropertyType::{prop.enum_type}, {{{len(values)} * sizeof({item_type})}}}},',
                     '{',
@@ -1024,7 +1026,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
                 ],
                 '};'
             ]
-            return '.enuminfo = &itemtype.enuminfo'
+            return f'.enuminfo = &{itemtype_var}.enuminfo'
         if prop.ptype == 'string':
             return f'.defaultString = &{db.strings[str(prop.default)]}' if prop.default else ''
         if prop.ptype == 'number':
@@ -1043,8 +1045,7 @@ def generate_typeinfo(db: Database, object_prop: Property) -> CodeLines:
         return ''
 
     proplist = []
-    aliaslist = []
-
+    aliaslist = [] 
     def add_alias(alias: str | list):
         if alias is None:
             return


### PR DESCRIPTION
Add support for multiple enum properties in an object. Closes #72.