### PR TITLE
PropertyConst does not require `defaultData`

### DIFF
--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -408,7 +408,7 @@ PropertyConst Object::getProperty(unsigned index) const
 		}
 		auto& prop = typeinfo().getProperty(index);
 		auto propData = getPropertyData(index);
-		return {getStore(), prop, propData, nullptr};
+		return {getStore(), prop, propData};
 	}
 }
 

--- a/src/include/ConfigDB/Array.h
+++ b/src/include/ConfigDB/Array.h
@@ -113,7 +113,7 @@ private:
 
 	PropertyConst makeProperty(const void* data) const
 	{
-		return {getStore(), getItemType(), static_cast<const PropertyData*>(data), nullptr};
+		return {getStore(), getItemType(), static_cast<const PropertyData*>(data)};
 	}
 };
 

--- a/src/include/ConfigDB/Property.h
+++ b/src/include/ConfigDB/Property.h
@@ -34,13 +34,12 @@ public:
 	PropertyConst() = default;
 
 	/**
-	 * @brief Create a Property instance
+	 * @brief Create a PropertyConst instance
 	 * @param info Property information
 	 * @param data Pointer to location where value is stored
 	 */
-	PropertyConst(const Store& store, const PropertyInfo& info, const PropertyData* data,
-				  const PropertyData* defaultData)
-		: propinfo(&info), store(&store), data(data), defaultData(defaultData)
+	PropertyConst(const Store& store, const PropertyInfo& info, const PropertyData* data)
+		: propinfo(&info), store(&store), data(data)
 	{
 	}
 
@@ -62,13 +61,23 @@ protected:
 	const PropertyInfo* propinfo{&PropertyInfo::empty};
 	const Store* store{};
 	const PropertyData* data{};
-	const PropertyData* defaultData{};
 };
 
 class Property : public PropertyConst
 {
 public:
-	using PropertyConst::PropertyConst;
+	Property() = default;
+
+	/**
+	 * @brief Create a Property instance
+	 * @param info Property information
+	 * @param data Pointer to location where value is stored
+	 * @param defaultData Pointer to default value for property (if any)
+	 */
+	Property(const Store& store, const PropertyInfo& info, const PropertyData* data, const PropertyData* defaultData)
+		: PropertyConst(store, info, data), defaultData(defaultData)
+	{
+	}
 
 	bool setJsonValue(const char* value, size_t valueLength);
 
@@ -76,6 +85,9 @@ public:
 	{
 		return setJsonValue(value.c_str(), value.length());
 	}
+
+protected:
+	const PropertyData* defaultData{};
 };
 
 } // namespace ConfigDB


### PR DESCRIPTION
A minor fix where `defaultData` is used only by a `Property` class, not by it's base const equivalent.