### PR TITLE
Fix bug causing empty strings to be stored more than once in string pool

### DIFF
--- a/src/include/ConfigDB/Pool.h
+++ b/src/include/ConfigDB/Pool.h
@@ -132,9 +132,12 @@ public:
 		return length == other.length && memcmp(value, other.value, length) == 0;
 	}
 
+	/**
+	 * @brief Valid contents include empty string, but not null string
+	 */
 	explicit operator bool() const
 	{
-		return value && length;
+		return value;
 	}
 
 	explicit operator String() const

--- a/test/modules/Update.cpp
+++ b/test/modules/Update.cpp
@@ -34,6 +34,29 @@ public:
 				REQUIRE_EQ(updater.getSimpleString(), banana);
 				updater.setSimpleString(nullptr);
 				REQUIRE_EQ(updater.getSimpleString(), donkey);
+				updater.setSimpleString(banana);
+				REQUIRE_EQ(updater.getSimpleString(), banana);
+				updater.resetSimpleString();
+				REQUIRE_EQ(updater.getSimpleString(), donkey);
+
+				/*
+				 * Check zero-length string is handled correctly.
+				 * Jan 2026 bug found in `CountedString` which caused multiple
+				 * copies of empty string to be stored in pool.
+				 */
+				TEST_CASE("Empty string")
+				{
+					auto& store = updater.getStore();
+					auto& pool = store.getStringPool();
+					updater.setSimpleString("");
+					auto startCount = pool.getCount();
+					for(unsigned i = 0; i < 10; ++i) {
+						updater.setSimpleString("");
+						CHECK_EQ(updater.getSimpleString(), "");
+						auto count = pool.getCount();
+						CHECK_EQ(count, startCount);
+					}
+				}
 			} else {
 				TEST_ASSERT(false);
 			}


### PR DESCRIPTION
`StringPool::find("")` returns 0 incorrectly because `CountedString` evaluates as false, which is incorrect.