### PR TITLE
Add streaming import union tests

### DIFF
--- a/src/include/ConfigDB/Union.h
+++ b/src/include/ConfigDB/Union.h
@@ -51,6 +51,9 @@ public:
 	 */
 	void setTag(Tag tag)
 	{
+		if(!writeCheck()) {
+			return;
+		}
 		assert(tag < typeinfo().objectCount);
 		disposeArrays();
 		memset(getDataPtr(), 0, typeinfo().structSize);
@@ -63,6 +66,9 @@ public:
 	 */
 	void clear()
 	{
+		if(!writeCheck()) {
+			return;
+		}
 		disposeArrays();
 		memset(getDataPtr(), 0, typeinfo().structSize);
 		getPropertyData(0)->uint8 = 0;

--- a/test/modules/Streaming.cpp
+++ b/test/modules/Streaming.cpp
@@ -144,7 +144,8 @@ public:
 		{
 			// An un-named root object should produce same output (i.e. options are ignored)
 			String expectedContent =
-				F("{\"int_array\":[13,28,39,40],\"string_array\":[\"a\",\"b\",\"c\"],\"object_array\":[],\"color\":"
+				F("{\"simple-union\":{\"obj2\":{\"value\":12}},\"int_array\":[13,28,39,40],\"string_array\":[\"a\","
+				  "\"b\",\"c\"],\"object_array\":[],\"color\":"
 				  "\"red\",\"simple-bool\":true,\"simple-string\":\"donkey\",\"simple-int\":100,\"simple-float\":3."
 				  "1415927}");
 			TestConfig::Root root(database);

--- a/test/resource/array_test_default.json
+++ b/test/resource/array_test_default.json
@@ -1,4 +1,9 @@
 {
+    "simple-union": {
+        "obj1": {
+            "value": 0
+        }
+    },
     "int_array": [
         1,
         2,

--- a/test/resource/async-update-result.json
+++ b/test/resource/async-update-result.json
@@ -1,1 +1,1 @@
-{"int_array":[100,1],"string_array":["go","away"],"object_array":[{"intval":1,"stringval":"biscuit"},{"intval":2,"stringval":"cake"}],"color":"green","simple-bool":true,"simple-string":"gorilla","simple-int":100,"simple-float":1.2e8}
+{"simple-union":{"obj1":{"value":0}},"int_array":[100,1],"string_array":["go","away"],"object_array":[{"intval":1,"stringval":"biscuit"},{"intval":2,"stringval":"cake"}],"color":"green","simple-bool":true,"simple-string":"gorilla","simple-int":100,"simple-float":1.2e8}

--- a/test/resource/database1.json
+++ b/test/resource/database1.json
@@ -1,1 +1,1 @@
-{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927,"array-store":[],"object-array-store":[]}
+{"simple-union":{"obj2":{"value":12}},"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927,"array-store":[],"object-array-store":[]}

--- a/test/resource/root1.json
+++ b/test/resource/root1.json
@@ -1,1 +1,1 @@
-{"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}
+{"simple-union":{"obj2":{"value":12}},"int_array":[13,28,39,40],"string_array":["a","b","c"],"object_array":[],"color":"red","simple-bool":true,"simple-string":"donkey","simple-int":100,"simple-float":3.1415927}

--- a/test/resource/update1.json
+++ b/test/resource/update1.json
@@ -1,4 +1,9 @@
 {
     "simple-bool": true,
-    "simple-int": 11111110101010
+    "simple-int": 11111110101010,
+    "simple-union": {
+        "obj2": {
+            "value": 12
+        }
+    }
 }

--- a/test/test-config.cfgdb
+++ b/test/test-config.cfgdb
@@ -30,6 +30,37 @@
       "default": 3.141592654,
       "maximum": 1.2e8
     },
+    "simple-union": {
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "obj1",
+          "properties": {
+            "value": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "obj2",
+          "properties": {
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "obj3",
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
     "int_array": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Notably absent from testing is behaviour of streaming updates to unions.
Bug fixed where assertion raised attempting to update union in read-only store.