### PR TITLE
Fix recursion bug

### DIFF
--- a/test/pr96-recur.cfgdb
+++ b/test/pr96-recur.cfgdb
@@ -1,0 +1,50 @@
+{
+  "comment": "Verify PR #96, where `oneof` contains nested definitions",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "my-color": {
+      "$ref": "#/$defs/color"
+    }
+  },
+  "$defs": {
+    "color": {
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "raw-wrapper",
+          "properties": {
+            "raw": {
+              "$ref": "#/$defs/raw"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "preset-wrapper",
+          "properties": {
+            "preset": {
+              "$ref": "#/$defs/preset"
+            }
+          }
+        }
+      ]
+    },
+    "raw": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "integer"
+        }
+      }
+    },
+    "preset": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -869,7 +869,7 @@ def parse_property(path: str, parent_prop: Property, key: str, fields: dict) -> 
                 prop = parse_property(f'{path}/oneOf/{i}', union_prop, opt.get('title'), opt)
                 if not prop.obj:
                     raise ValueError(f'Union "{union_prop.name}" option type must be *object*')
-                if not prop.id or not prop.obj.typename:
+                if not prop.id or not prop.name or not prop.obj.typename:
                     raise ValueError(f'Union "{union_prop.name}" option requires title or $ref')
             if union_prop.obj.max_object_size == 0:
                 raise ValueError('Union contains only empty objects')

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -509,7 +509,8 @@ class Object:
                 if prop.obj in dependencies:
                     continue
                 dependencies.append(prop.obj)
-                scan(prop.obj)
+                if scan(prop.obj):
+                    return True
             return False
         return scan(self)
 


### PR DESCRIPTION
This PR fixes two bugs identified by issue #95:

Union members identified using oneof require a title option if defined directly, otherwise the object name is empty which is not valid. The logic used to catch this was incomplete and results either in a python recursion error if there are multiple such definitions, or invalid code being generated if only one such un-titled definition exists. Both situations are confusing, so an additional check has been added which catches this issue during code generation.

Generated classes may not be in the correct order, resulting in compilation errors such as 'struct not yet fully defined'. This was due to to a bug when sorting dependencies with nested definitions. Sample config pr96-recur.cfgdb added to test.
