### PR TITLE
Fix alignment bug caused by empty objects

### DIFF
--- a/test/include/modules.h
+++ b/test/include/modules.h
@@ -1,6 +1,7 @@
 // List of test modules to register
 
 #define TEST_MAP(XX)                                                                                                   \
+	XX(Bugs)                                                                                                           \
 	XX(Update)                                                                                                         \
 	XX(Sharing)                                                                                                        \
 	XX(Streaming)                                                                                                      \

--- a/test/modules/Bugs.cpp
+++ b/test/modules/Bugs.cpp
@@ -1,0 +1,36 @@
+/*
+ * Bugs.cpp
+ */
+
+#include <ConfigDBTest.h>
+#include <test-bugs.h>
+
+class BugsTest : public TestGroup
+{
+public:
+	BugsTest() : TestGroup(_F("Bugs"))
+	{
+	}
+
+	void execute() override
+	{
+		TestBugs bugs("");
+		TestBugs::Root root(bugs);
+
+		TEST_CASE("Empty Object misalignment bug")
+		{
+			/*
+				Empty struct is allocated 1 byte by compiler.
+				This means calculated positions (by dbgen.py) and those in a struct
+				definition will not match.
+				Default values are stored as a struct so this check fails.
+			*/
+			REQUIRE_EQ(root.getGuard(), 555);
+		}
+	}
+};
+
+void REGISTER_TEST(Bugs)
+{
+	registerGroup<BugsTest>();
+}

--- a/test/test-bugs.cfgdb
+++ b/test/test-bugs.cfgdb
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "empty": {
+      "type": "object",
+      "description": "Must preceded 'guard' for checking struct alignment"
+    },
+    "guard": {
+      "type": "integer",
+      "default": 555
+    }
+  }
+}

--- a/tools/dbgen.py
+++ b/tools/dbgen.py
@@ -1334,15 +1334,16 @@ def generate_object_struct(object_prop: ObjectProperty) -> CodeLines:
     obj = object_prop.obj
 
     typename = f'{object_prop.namespace}::{obj.typename_contained}'
+    struct_props = [prop for prop in obj.object_properties if prop.obj.has_struct]
     return CodeLines([
         '',
         'struct __attribute__((packed)) Struct {',
         [
             'union __attribute__((packed)) {',
-            [f'{prop.obj.typename_struct} {prop.id}{"{}" if index == 0 else ""};' for index, prop in enumerate(obj.object_properties)],
+            [f'{prop.obj.typename_struct} {prop.id}{"{}" if index == 0 else ""};' for index, prop in enumerate(struct_props)],
             '};',
         ] if obj.is_union else
-        [f'{prop.obj.typename_struct} {prop.id}{{}};' for prop in obj.object_properties],
+        [f'{prop.obj.typename_struct} {prop.id}{{}};' for prop in struct_props],
         [f'{get_ctype(prop)} {prop.id}{{{get_default(prop)}}};' for prop in obj.properties],
         '};',
         '',
@@ -1517,7 +1518,8 @@ def generate_object(db: Database, object_prop: ObjectProperty) -> CodeLines:
         if not prop.obj.ref and prop.obj.namespace.startswith(db.namespace):
             lines.append(generate_object(db, prop))
 
-    lines.append(generate_object_struct(object_prop))
+    if object_prop.obj.has_struct:
+        lines.append(generate_object_struct(object_prop))
     lines.header += [
         constructors,
         *generate_property_accessors(obj)


### PR DESCRIPTION
This PR fixes a bug demonstrated by the following schema:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "empty": {
      "type": "object",
      "description": "Must preceded 'guard' for checking struct alignment"
    },
    "guard": {
      "type": "integer",
      "default": 555
    }
  }
}
```

The struct which provides default values is generated as:

```c++
struct __attribute__((packed)) Struct {
    ContainedEmpty::Struct empty{};
    int32_t guard{555};
};
```

Because C++ allocates one byte to empty structures, `guard` is misaligned.

The code generator is now updated so that empty structs are omitted entirely:

```c++
struct __attribute__((packed)) Struct {
    int32_t guard{555};
};
```
